### PR TITLE
chore: refresh dependencies across all packages

### DIFF
--- a/demo/linux/flutter/generated_plugin_registrant.cc
+++ b/demo/linux/flutter/generated_plugin_registrant.cc
@@ -6,13 +6,21 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <irondash_engine_context/irondash_engine_context_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <super_native_extensions/super_native_extensions_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) irondash_engine_context_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "IrondashEngineContextPlugin");
+  irondash_engine_context_plugin_register_with_registrar(irondash_engine_context_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) super_native_extensions_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SuperNativeExtensionsPlugin");
+  super_native_extensions_plugin_register_with_registrar(super_native_extensions_registrar);
   g_autoptr(FlPluginRegistrar) window_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
   window_manager_plugin_register_with_registrar(window_manager_registrar);

--- a/demo/linux/flutter/generated_plugins.cmake
+++ b/demo/linux/flutter/generated_plugins.cmake
@@ -3,11 +3,14 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  irondash_engine_context
   screen_retriever_linux
+  super_native_extensions
   window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demo/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demo/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,16 +5,20 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_foundation
+import device_info_plus
+import irondash_engine_context
 import screen_retriever_macos
 import sqflite_darwin
+import super_native_extensions
 import webview_flutter_wkwebview
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
+  IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  SuperNativeExtensionsPlugin.register(with: registry.registrar(forPlugin: "SuperNativeExtensionsPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_fonts: ^6.3.2
+  google_fonts: ^8.1.0
   mesh: ^0.4.3
   mix: ^2.0.3
   superdeck_core: ^1.0.0
   superdeck: ^1.0.0
-  signals_flutter: ^6.0.4
+  signals_flutter: ^7.0.0
   naked_ui: ^0.2.0-beta.7
   remix: ^0.2.0
 dev_dependencies:

--- a/demo/windows/flutter/generated_plugin_registrant.cc
+++ b/demo/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,18 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <irondash_engine_context/irondash_engine_context_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <super_native_extensions/super_native_extensions_plugin_c_api.h>
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  IrondashEngineContextPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("IrondashEngineContextPluginCApi"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  SuperNativeExtensionsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SuperNativeExtensionsPluginCApi"));
   WindowManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/demo/windows/flutter/generated_plugins.cmake
+++ b/demo/windows/flutter/generated_plugins.cmake
@@ -3,11 +3,14 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  irondash_engine_context
   screen_retriever_windows
+  super_native_extensions
   window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/packages/builder/pubspec.yaml
+++ b/packages/builder/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
   path: ^1.9.0
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.1.0
   test: ^1.25.8
   dart_code_metrics_presets: ^2.19.0

--- a/packages/cli/pubspec.yaml
+++ b/packages/cli/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
 
 dev_dependencies:
   dart_code_metrics_presets: ^2.19.0
-  lints: ^5.0.0
+  lints: ^6.1.0
   test: ^1.25.8

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   yaml: ^3.1.2
   collection: ^1.18.0
   path: ^1.9.0
-  ack: 1.0.0-beta.9
+  ack: 1.0.0-beta.11
   dart_mappable: ^4.7.0
   markdown: ^7.3.0
   logging: ^1.3.0

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   logging: ^1.3.0
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.1.0
   test: ^1.24.0
   dart_code_metrics_presets: ^2.19.0
   build_runner: ^2.5.4

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   collection: ^1.18.0
   dart_mappable: ^4.7.0
   path: ^1.9.0
-  syntax_highlight: ^0.4.0
+  syntax_highlight: ^0.5.0
   scrollable_positioned_list: ^0.3.8
   go_router: ^14.2.7
   path_provider: ^2.1.4

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   markdown: ^7.3.0
   web: ^1.1.0
   webview_flutter: ^4.10.0
-  google_fonts: ^6.3.2
+  google_fonts: ^8.1.0
   qr_flutter: ^4.1.0
   signals: ^6.2.0
   signals_flutter: ^6.2.0

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   path: ^1.9.0
   syntax_highlight: ^0.5.0
   scrollable_positioned_list: ^0.3.8
-  go_router: ^14.2.7
+  go_router: ^17.2.3
   path_provider: ^2.1.4
   mix: ^2.0.3
   remix: ^0.2.0

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -30,8 +30,8 @@ dependencies:
   webview_flutter: ^4.10.0
   google_fonts: ^8.1.0
   qr_flutter: ^4.1.0
-  signals: ^6.2.0
-  signals_flutter: ^6.2.0
+  signals: ^7.0.0
+  signals_flutter: ^7.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   cached_network_image: ^3.4.1
-  window_manager: ^0.4.3
+  window_manager: ^0.5.1
   collection: ^1.18.0
   dart_mappable: ^4.7.0
   path: ^1.9.0

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -28,9 +28,7 @@ dependencies:
   markdown: ^7.3.0
   web: ^1.1.0
   webview_flutter: ^4.10.0
-  webview_flutter_web: ^0.2.3
   google_fonts: ^6.3.2
-  meta: ^1.16.0
   qr_flutter: ^4.1.0
   signals: ^6.2.0
   signals_flutter: ^6.2.0


### PR DESCRIPTION
## Summary
- **superdeck**: drops unused `meta` and `webview_flutter_web`; bumps `window_manager` ^0.5.1, `syntax_highlight` ^0.5.0, `google_fonts` ^8.1.0, `go_router` ^17.2.3, `signals`/`signals_flutter` ^7.0.0 (`Watch` deprecated → `SignalBuilder` migration left for follow-up).
- **core**: bumps `ack` to `1.0.0-beta.11`.
- **core / cli / builder**: bump dev `lints` to ^6.1.0.
- Each bump is a focused commit; `dart analyze` is clean and tests pass on every package after every step (superdeck 538/538, core 616/616, cli 35/35, builder 75/75).

## Test plan
- [x] `fvm flutter pub get` / `fvm dart pub get` resolve in each package
- [x] `fvm dart analyze` clean in each package (only `signals` v7 `Watch` deprecation infos remain in superdeck)
- [x] All unit tests pass in core, cli, builder, and superdeck
- [ ] Manual smoke test of the demo app

🤖 Generated with [Claude Code](https://claude.com/claude-code)