### PR TITLE
feat: re-add window_manager for desktop window sizing

### DIFF
--- a/demo/linux/flutter/generated_plugin_registrant.cc
+++ b/demo/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,17 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_saver/file_saver_plugin.h>
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_saver_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSaverPlugin");
   file_saver_plugin_register_with_registrar(file_saver_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
 }

--- a/demo/linux/flutter/generated_plugins.cmake
+++ b/demo/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,8 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_saver
+  screen_retriever_linux
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/demo/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demo/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,15 @@ import FlutterMacOS
 import Foundation
 
 import file_saver
+import screen_retriever_macos
 import sqflite_darwin
 import webview_flutter_wkwebview
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/demo/windows/flutter/generated_plugin_registrant.cc
+++ b/demo/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_saver/file_saver_plugin.h>
+#include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSaverPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSaverPlugin"));
+  ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  WindowManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/demo/windows/flutter/generated_plugins.cmake
+++ b/demo/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,8 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_saver
+  screen_retriever_windows
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/playground/macos/Flutter/Flutter-Debug.xcconfig
+++ b/packages/playground/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/packages/playground/macos/Flutter/Flutter-Release.xcconfig
+++ b/packages/playground/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/packages/playground/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/playground/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,19 @@ import FlutterMacOS
 import Foundation
 
 import audioplayers_darwin
+import screen_retriever_macos
 import sqflite_darwin
 import url_launcher_macos
 import video_player_avfoundation
 import webview_flutter_wkwebview
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/packages/playground/macos/Podfile
+++ b/packages/playground/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/packages/superdeck/lib/src/utils/app_initialization.dart
+++ b/packages/superdeck/lib/src/utils/app_initialization.dart
@@ -1,9 +1,38 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart' show Colors;
 import 'package:flutter/widgets.dart';
+import 'package:window_manager/window_manager.dart';
 
+import 'constants.dart';
 import 'syntax_highlighter.dart';
 
 Future<void> initializeDependencies() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await SyntaxHighlight.initialize();
+  await Future.wait([SyntaxHighlight.initialize(), _initializeWindowManager()]);
+}
+
+Future<void> _initializeWindowManager() async {
+  if (kIsWeb || kIsTest) return;
+
+  await windowManager.ensureInitialized();
+
+  final size = Size(kResolution.width, kResolution.height);
+
+  final windowOptions = WindowOptions(
+    size: size,
+    backgroundColor: Colors.black,
+    skipTaskbar: false,
+    minimumSize: size,
+    windowButtonVisibility: true,
+    title: 'Superdeck',
+    titleBarStyle: TitleBarStyle.hidden,
+  );
+
+  windowManager.waitUntilReadyToShow(windowOptions, () async {
+    await windowManager.show();
+    await windowManager.focus();
+  });
+
+  await windowManager.setAspectRatio(kAspectRatio);
 }

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   cached_network_image: ^3.4.1
+  window_manager: ^0.4.3
   collection: ^1.18.0
   dart_mappable: ^4.7.0
   path: ^1.9.0


### PR DESCRIPTION
## Summary
- Re-adds the `window_manager` dependency to `superdeck` and initializes it on desktop (macOS/Linux/Windows) to set a fixed 1280x720 window, lock the 16:9 aspect ratio, and use a hidden title bar.
- Regenerates plugin registrants, xcconfig includes, and the macOS Podfile for the `window_manager` and `screen_retriever` plugin dependencies across `demo` and `packages/playground`.

## Test plan
- [x] `melos bootstrap`
- [x] `melos run analyze`
- [x] Run demo/playground on macOS and confirm window opens at fixed size with locked aspect ratio