### PR TITLE
chore: upgrade window_manager to ^0.5.2

### DIFF
--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   cached_network_image: ^3.4.1
-  window_manager: ^0.4.3
+  window_manager: ^0.5.2
   collection: ^1.18.0
   dart_mappable: ^4.7.0
   path: ^1.9.0


### PR DESCRIPTION
## Summary
- Bumps `window_manager` from `^0.4.3` to `^0.5.2` in `packages/superdeck/pubspec.yaml`.
- `0.5.2` ships Swift Package Manager support (`Package.swift`), matching Flutter 3.44's default SPM resolution and avoiding the CocoaPods fallback that `0.4.3` required on macOS.
- All existing `window_manager` API calls used by SuperDeck (`WindowOptions`, `waitUntilReadyToShow`, `show`, `focus`, `setAspectRatio`) remain unchanged in `0.5.2`.

## Test plan
- [x] `melos bootstrap`
- [x] `melos run analyze` (all packages pass, no issues found)
- [x] `dart pub get` in `packages/superdeck` resolves `window_manager 0.5.2`