### PR TITLE
chore: update dependencies to latest versions

### DIFF
--- a/demo/integration_test/layout_matrix_test.dart
+++ b/demo/integration_test/layout_matrix_test.dart
@@ -752,8 +752,8 @@ WidgetBlock _image(
     args: {
       'src': src,
       'fit': fit,
-      if (width != null) 'width': width,
-      if (height != null) 'height': height,
+      'width': ?width,
+      'height': ?height,
     },
   );
 }

--- a/demo/linux/flutter/generated_plugin_registrant.cc
+++ b/demo/linux/flutter/generated_plugin_registrant.cc
@@ -7,16 +7,24 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_saver/file_saver_plugin.h>
+#include <irondash_engine_context/irondash_engine_context_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <super_native_extensions/super_native_extensions_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_saver_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSaverPlugin");
   file_saver_plugin_register_with_registrar(file_saver_registrar);
+  g_autoptr(FlPluginRegistrar) irondash_engine_context_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "IrondashEngineContextPlugin");
+  irondash_engine_context_plugin_register_with_registrar(irondash_engine_context_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) super_native_extensions_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SuperNativeExtensionsPlugin");
+  super_native_extensions_plugin_register_with_registrar(super_native_extensions_registrar);
   g_autoptr(FlPluginRegistrar) window_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
   window_manager_plugin_register_with_registrar(window_manager_registrar);

--- a/demo/linux/flutter/generated_plugins.cmake
+++ b/demo/linux/flutter/generated_plugins.cmake
@@ -4,7 +4,9 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_saver
+  irondash_engine_context
   screen_retriever_linux
+  super_native_extensions
   window_manager
 )
 

--- a/demo/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demo/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,16 +5,22 @@
 import FlutterMacOS
 import Foundation
 
+import device_info_plus
 import file_saver
+import irondash_engine_context
 import screen_retriever_macos
 import sqflite_darwin
+import super_native_extensions
 import webview_flutter_wkwebview
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
+  IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  SuperNativeExtensionsPlugin.register(with: registry.registrar(forPlugin: "SuperNativeExtensionsPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -9,11 +9,11 @@ dependencies:
   flutter:
     sdk: flutter
   google_fonts: ^8.1.0
-  mesh: ^0.4.3
+  mesh: ^0.5.0
   mix: ^2.1.0
   superdeck_core: ^1.0.0
   superdeck: ^1.0.0
-  signals_flutter: ^6.0.4
+  signals_flutter: ^7.1.0
   naked_ui: ^0.2.0-beta.7
   remix: ^0.2.0
 dev_dependencies:
@@ -21,7 +21,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   superdeck_builder: ^1.0.0
   superdeck_cli: ^1.0.0
   superdeck_mermaid: ^1.0.0

--- a/demo/windows/flutter/generated_plugin_registrant.cc
+++ b/demo/windows/flutter/generated_plugin_registrant.cc
@@ -7,14 +7,20 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_saver/file_saver_plugin.h>
+#include <irondash_engine_context/irondash_engine_context_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <super_native_extensions/super_native_extensions_plugin_c_api.h>
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSaverPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSaverPlugin"));
+  IrondashEngineContextPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("IrondashEngineContextPluginCApi"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  SuperNativeExtensionsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SuperNativeExtensionsPluginCApi"));
   WindowManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/demo/windows/flutter/generated_plugins.cmake
+++ b/demo/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,9 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_saver
+  irondash_engine_context
   screen_retriever_windows
+  super_native_extensions
   window_manager
 )
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -14,7 +14,8 @@ command:
     dependencies:
       collection: ^1.18.0
       mix: ^2.1.0
-      ack: 1.0.0-beta.12
+      remix: ^0.2.0
+      ack: 1.0.1
   # publish:
     # hooks:
     #   pre: melos run gen:build

--- a/packages/builder/pubspec.yaml
+++ b/packages/builder/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
   path: ^1.9.0
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.1.0
   test: ^1.25.8
   dart_code_metrics_presets: ^2.19.0

--- a/packages/cli/pubspec.yaml
+++ b/packages/cli/pubspec.yaml
@@ -22,5 +22,5 @@ dependencies:
 
 dev_dependencies:
   dart_code_metrics_presets: ^2.19.0
-  lints: ^5.0.0
+  lints: ^6.1.0
   test: ^1.25.8

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -14,13 +14,13 @@ dependencies:
   yaml: ^3.1.2
   collection: ^1.18.0
   path: ^1.9.0
-  ack: 1.0.0-beta.12
+  ack: 1.0.1
   dart_mappable: ^4.7.0
   markdown: ^7.3.0
   logging: ^1.3.0
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.1.0
   test: ^1.24.0
   dart_code_metrics_presets: ^2.19.0
   build_runner: ^2.5.4

--- a/packages/playground/lib/features/ai/wizard/chat/view/widgets/chat_genui_panels.dart
+++ b/packages/playground/lib/features/ai/wizard/chat/view/widgets/chat_genui_panels.dart
@@ -17,14 +17,14 @@ const _bubbleBorderRadius = BorderRadius.only(
 );
 
 /// Typing indicator bubble - shows only when AI is thinking.
-class TypingBubble extends StatelessWidget {
+class TypingBubble extends SignalWidget {
   const TypingBubble({super.key, required this.isThinking});
 
   final ReadonlySignal<bool> isThinking;
 
   @override
   Widget build(BuildContext context) {
-    final thinking = isThinking.watch(context);
+    final thinking = isThinking.value;
 
     if (!thinking) return const SizedBox.shrink();
 
@@ -48,7 +48,7 @@ class TypingBubble extends StatelessWidget {
 }
 
 /// Message bubble - shows the last AI message (hidden when thinking).
-class GenUiMessageBubble extends StatelessWidget {
+class GenUiMessageBubble extends SignalWidget {
   const GenUiMessageBubble({
     super.key,
     required this.isThinking,
@@ -69,8 +69,8 @@ class GenUiMessageBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final currentMessages = messages.watch(context);
-    final thinking = isThinking.watch(context);
+    final currentMessages = messages.value;
+    final thinking = isThinking.value;
 
     final lastAiMessage = currentMessages.reversed
         .whereType<SuperdeckAiMessage>()
@@ -90,7 +90,7 @@ class GenUiMessageBubble extends StatelessWidget {
 }
 
 /// Shared surfaces panel used by AI conversation screens.
-class AiSurfacesPanel extends StatelessWidget {
+class AiSurfacesPanel extends SignalWidget {
   const AiSurfacesPanel({
     super.key,
     required this.controller,
@@ -110,8 +110,8 @@ class AiSurfacesPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ids = surfaceIds.watch(context);
-    final thinking = isThinking.watch(context);
+    final ids = surfaceIds.value;
+    final thinking = isThinking.value;
 
     final flex = FlexBoxStyler()
         .spacing(16)
@@ -173,7 +173,7 @@ class AiSurfacesPanel extends StatelessWidget {
                     isThinking: isThinking,
                     messages: messages,
                   ),
-                  if (surfacesWidget != null) surfacesWidget,
+                  ?surfacesWidget,
                 ],
               ),
             ),
@@ -187,7 +187,7 @@ class AiSurfacesPanel extends StatelessWidget {
 }
 
 /// Shared chat body panel used by AI conversation screens.
-class ChatBodyPanel extends StatelessWidget {
+class ChatBodyPanel extends SignalWidget {
   const ChatBodyPanel({
     super.key,
     required this.messages,
@@ -205,7 +205,7 @@ class ChatBodyPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final thinking = isThinking.watch(context);
+    final thinking = isThinking.value;
 
     return Column(
       children: [
@@ -217,10 +217,7 @@ class ChatBodyPanel extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             spacing: 8,
-            children: [
-              if (thinking) const LoadingResponse(),
-              if (inputWidget != null) inputWidget!,
-            ],
+            children: [if (thinking) const LoadingResponse(), ?inputWidget],
           ),
         ),
       ],
@@ -229,7 +226,7 @@ class ChatBodyPanel extends StatelessWidget {
 }
 
 /// Shared message list used by AI conversation body panels.
-class MessageList extends StatelessWidget {
+class MessageList extends SignalWidget {
   const MessageList({
     super.key,
     required this.messages,
@@ -241,7 +238,7 @@ class MessageList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final currentMessages = messages.watch(context);
+    final currentMessages = messages.value;
     final reversedMessages = currentMessages.reversed.toList();
 
     if (currentMessages.isEmpty) {

--- a/packages/playground/lib/features/ai/wizard/presentation/wizard_view.dart
+++ b/packages/playground/lib/features/ai/wizard/presentation/wizard_view.dart
@@ -66,48 +66,50 @@ class _WizardBodyState extends State<_WizardBody> {
   Widget build(BuildContext context) {
     final viewModel = context.read<AiConversationViewModel>();
 
-    return Watch((context) {
-      final started = viewModel.hasConversationStarted.value;
-      final messages = viewModel.messages.value;
-      final isThinking = viewModel.isThinking.value;
+    return SignalBuilder(
+      builder: (context) {
+        final started = viewModel.hasConversationStarted.value;
+        final messages = viewModel.messages.value;
+        final isThinking = viewModel.isThinking.value;
 
-      final input = ChatInput(
-        controller: _controller,
-        focusNode: _focusNode,
-        enabled: !isThinking,
-        onSubmitted: _submit,
-      );
+        final input = ChatInput(
+          controller: _controller,
+          focusNode: _focusNode,
+          enabled: !isThinking,
+          onSubmitted: _submit,
+        );
 
-      // Before the first message: show the empty state with the topic prompt.
-      // It centers when it fits and scrolls when the sidebar is too short.
-      if (!started && messages.isEmpty) {
-        return Column(
-          children: [
-            Expanded(
-              child: LayoutBuilder(
-                builder: (context, constraints) => SingleChildScrollView(
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(
-                      minHeight: constraints.maxHeight,
+        // Before the first message: show the empty state with the topic prompt.
+        // It centers when it fits and scrolls when the sidebar is too short.
+        if (!started && messages.isEmpty) {
+          return Column(
+            children: [
+              Expanded(
+                child: LayoutBuilder(
+                  builder: (context, constraints) => SingleChildScrollView(
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: constraints.maxHeight,
+                      ),
+                      child: EmptyState(onSuggestionTap: _submit),
                     ),
-                    child: EmptyState(onSuggestionTap: _submit),
                   ),
                 ),
               ),
-            ),
-            input,
-          ],
-        );
-      }
+              input,
+            ],
+          );
+        }
 
-      // Conversation in progress: render the current surface + input inline.
-      return AiSurfacesPanel(
-        controller: viewModel.controller,
-        surfaceIds: viewModel.surfaceIds,
-        isThinking: viewModel.isThinking,
-        messages: viewModel.messages,
-        inputWidget: input,
-      );
-    });
+        // Conversation in progress: render the current surface + input inline.
+        return AiSurfacesPanel(
+          controller: viewModel.controller,
+          surfaceIds: viewModel.surfaceIds,
+          isThinking: viewModel.isThinking,
+          messages: viewModel.messages,
+          inputWidget: input,
+        );
+      },
+    );
   }
 }

--- a/packages/playground/lib/features/editor/presentation/widgets/preview_sidebar.dart
+++ b/packages/playground/lib/features/editor/presentation/widgets/preview_sidebar.dart
@@ -37,8 +37,9 @@ class PreviewSidebar extends StatelessWidget {
 /// always current and there's nothing to regenerate. `ListView.builder` keeps
 /// this to the on-screen previews.
 ///
-/// Slides come straight from `DeckController.slides` (a signal) via [Watch]; the
-/// active-slide highlight still comes from `EditorStore` through Provider.
+/// Slides come straight from `DeckController.slides` (a signal) via
+/// [SignalBuilder]; the active-slide highlight still comes from `EditorStore`
+/// through Provider.
 class SlidesPreviewList extends StatelessWidget {
   const SlidesPreviewList({super.key});
 
@@ -49,38 +50,40 @@ class SlidesPreviewList extends StatelessWidget {
       (store) => store.activeSlideIndex,
     );
 
-    return Watch((context) {
-      final slides = controller.slides.value;
+    return SignalBuilder(
+      builder: (context) {
+        final slides = controller.slides.value;
 
-      if (slides.isEmpty) {
-        return Center(
-          child: StyledText(
-            'No slides',
-            style: TextStyler().style(.color($muted())),
+        if (slides.isEmpty) {
+          return Center(
+            child: StyledText(
+              'No slides',
+              style: TextStyler().style(.color($muted())),
+            ),
+          );
+        }
+
+        return ScrollConfiguration(
+          behavior: ScrollBehavior().copyWith(scrollbars: false),
+          child: ListView.builder(
+            clipBehavior: .none,
+            itemCount: slides.length,
+            itemBuilder: (context, index) {
+              return Padding(
+                padding: const .only(bottom: 24),
+                child: _PreviewItem(
+                  index: index,
+                  configuration: slides[index],
+                  isActive: index == activeIndex,
+                  onTap: () =>
+                      context.read<EditorStore>().activeSlideIndex = index,
+                ),
+              );
+            },
           ),
         );
-      }
-
-      return ScrollConfiguration(
-        behavior: ScrollBehavior().copyWith(scrollbars: false),
-        child: ListView.builder(
-          clipBehavior: .none,
-          itemCount: slides.length,
-          itemBuilder: (context, index) {
-            return Padding(
-              padding: const .only(bottom: 24),
-              child: _PreviewItem(
-                index: index,
-                configuration: slides[index],
-                isActive: index == activeIndex,
-                onTap: () =>
-                    context.read<EditorStore>().activeSlideIndex = index,
-              ),
-            );
-          },
-        ),
-      );
-    });
+      },
+    );
   }
 }
 

--- a/packages/playground/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/playground/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,8 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import audioplayers_darwin
+import device_info_plus
+import irondash_engine_context
 import screen_retriever_macos
 import sqflite_darwin
+import super_native_extensions
 import url_launcher_macos
 import video_player_avfoundation
 import webview_flutter_wkwebview
@@ -15,8 +18,11 @@ import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
+  IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  SuperNativeExtensionsPlugin.register(with: registry.registrar(forPlugin: "SuperNativeExtensionsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))

--- a/packages/playground/pubspec.yaml
+++ b/packages/playground/pubspec.yaml
@@ -11,12 +11,12 @@ dependencies:
     sdk: flutter
   # State management & DI — Provider + Command pattern.
   provider: ^6.1.2
-  go_router: ^14.0.0
+  go_router: ^17.3.0
   # signals: core/ bridge stores translate DeckController signals into
   # ChangeNotifier; signals_flutter lets the UI watch DeckController.slides
   # directly, so slides need no bridge store.
-  signals: ^6.2.0
-  signals_flutter: ^6.2.0
+  signals: ^7.1.0
+  signals_flutter: ^7.1.0
   # UI
   mix: ^2.1.0
   remix: ^0.2.0
@@ -35,15 +35,15 @@ dependencies:
     path: ../builder
   # AI generation
   genui: ^0.9.2
-  googleai_dart: ^8.0.0
-  google_cloud_ai_generativelanguage_v1beta: ^0.4.0
+  googleai_dart: ^9.0.0
+  google_cloud_ai_generativelanguage_v1beta: ^0.5.2
   http: ^1.5.0
   gpt_markdown: ^1.1.4
   dotprompt_dart: ^0.5.0
   path: ^1.9.0
-  ack: 1.0.0-beta.12
-  ack_annotations: 1.0.0-beta.12
-  ack_json_schema_builder: 1.0.0-beta.12
+  ack: 1.0.1
+  ack_annotations: 1.0.1
+  ack_json_schema_builder: 1.0.1
   dartantic_ai: ^3.1.0
   json_schema_builder: ^0.1.5
 
@@ -52,9 +52,9 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   build_runner: ^2.5.4
-  ack_generator: 1.0.0-beta.12
+  ack_generator: 1.0.1
 
 flutter:
   uses-material-design: true

--- a/packages/plugins/mermaid/pubspec.yaml
+++ b/packages/plugins/mermaid/pubspec.yaml
@@ -18,6 +18,6 @@ dependencies:
   superdeck_core: ^1.0.0
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.1.0
   test: ^1.25.8
   dart_code_metrics_presets: ^2.19.0

--- a/packages/plugins/pdf/lib/src/pdf_export_screen.dart
+++ b/packages/plugins/pdf/lib/src/pdf_export_screen.dart
@@ -138,45 +138,47 @@ class _PdfExportDialogScreenState extends State<PdfExportDialogScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Watch((context) {
-      _exportController.exportStatus.value;
+    return SignalBuilder(
+      builder: (context) {
+        _exportController.exportStatus.value;
 
-      return Stack(
-        fit: StackFit.expand,
-        children: [
-          Center(
-            child: SizedBox.fromSize(
-              size: superDeckSlideSize,
-              child: PageView.builder(
-                controller: _exportController.pageController,
-                itemCount: _exportController.slides.length,
-                itemBuilder: (context, index) {
-                  final slide = _exportController.slides[index].copyWith(
-                    isStaticRendering: true,
-                    debug: false,
-                  );
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            Center(
+              child: SizedBox.fromSize(
+                size: superDeckSlideSize,
+                child: PageView.builder(
+                  controller: _exportController.pageController,
+                  itemCount: _exportController.slides.length,
+                  itemBuilder: (context, index) {
+                    final slide = _exportController.slides[index].copyWith(
+                      isStaticRendering: true,
+                      debug: false,
+                    );
 
-                  return RepaintBoundary(
-                    key: _exportController.getSlideKey(slide),
-                    child: _PdfSlideCaptureView(slide: slide),
-                  );
+                    return RepaintBoundary(
+                      key: _exportController.getSlideKey(slide),
+                      child: _PdfSlideCaptureView(slide: slide),
+                    );
+                  },
+                ),
+              ),
+            ),
+            const ModalBarrier(color: Colors.black, dismissible: false),
+            Center(
+              child: _PdfExportBar(
+                exportController: _exportController,
+                onCancel: () {
+                  _exportController.cancel();
+                  _close();
                 },
               ),
             ),
-          ),
-          const ModalBarrier(color: Colors.black, dismissible: false),
-          Center(
-            child: _PdfExportBar(
-              exportController: _exportController,
-              onCancel: () {
-                _exportController.cancel();
-                _close();
-              },
-            ),
-          ),
-        ],
-      );
-    });
+          ],
+        );
+      },
+    );
   }
 }
 
@@ -202,76 +204,78 @@ class _PdfExportBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Watch((context) {
-      final status = exportController.exportStatus.value;
-      final progressValue = exportController.progress.value;
-      final (current, total) = exportController.progressTuple.value;
-      final theme = Theme.of(context);
-      final indicatorValue = status == PdfExportStatus.capturing
-          ? progressValue
-          : null;
-      final isDone = switch (status) {
-        PdfExportStatus.complete || PdfExportStatus.failed => true,
-        _ => false,
-      };
+    return SignalBuilder(
+      builder: (context) {
+        final status = exportController.exportStatus.value;
+        final progressValue = exportController.progress.value;
+        final (current, total) = exportController.progressTuple.value;
+        final theme = Theme.of(context);
+        final indicatorValue = status == PdfExportStatus.capturing
+            ? progressValue
+            : null;
+        final isDone = switch (status) {
+          PdfExportStatus.complete || PdfExportStatus.failed => true,
+          _ => false,
+        };
 
-      final progressText = switch (status) {
-        PdfExportStatus.building => 'Building PDF...',
-        PdfExportStatus.complete => 'Done',
-        PdfExportStatus.capturing => 'Exporting $current / $total',
-        PdfExportStatus.idle => 'Exporting $current / $total',
-        PdfExportStatus.preparing => 'Preparing...',
-        PdfExportStatus.failed =>
-          exportController.exportError.value ?? 'Export failed',
-      };
+        final progressText = switch (status) {
+          PdfExportStatus.building => 'Building PDF...',
+          PdfExportStatus.complete => 'Done',
+          PdfExportStatus.capturing => 'Exporting $current / $total',
+          PdfExportStatus.idle => 'Exporting $current / $total',
+          PdfExportStatus.preparing => 'Preparing...',
+          PdfExportStatus.failed =>
+            exportController.exportError.value ?? 'Export failed',
+        };
 
-      return ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 360, minWidth: 280),
-        child: Material(
-          color: const Color(0xff171717),
-          elevation: 24,
-          borderRadius: BorderRadius.circular(8),
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                switch (status) {
-                  PdfExportStatus.complete => Icon(
-                    Icons.check_circle,
-                    color: theme.colorScheme.primary,
-                    size: 32,
+        return ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 360, minWidth: 280),
+          child: Material(
+            color: const Color(0xff171717),
+            elevation: 24,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  switch (status) {
+                    PdfExportStatus.complete => Icon(
+                      Icons.check_circle,
+                      color: theme.colorScheme.primary,
+                      size: 32,
+                    ),
+                    PdfExportStatus.failed => Icon(
+                      Icons.error,
+                      color: theme.colorScheme.error,
+                      size: 32,
+                    ),
+                    _ => SizedBox(
+                      height: 32,
+                      width: 32,
+                      child: CircularProgressIndicator(value: indicatorValue),
+                    ),
+                  },
+                  const SizedBox(height: 16.0),
+                  Text(
+                    progressText,
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: Colors.white,
+                    ),
                   ),
-                  PdfExportStatus.failed => Icon(
-                    Icons.error,
-                    color: theme.colorScheme.error,
-                    size: 32,
+                  const SizedBox(height: 20.0),
+                  ElevatedButton.icon(
+                    onPressed: onCancel,
+                    icon: Icon(isDone ? Icons.close : Icons.cancel),
+                    label: Text(isDone ? 'Close' : 'Cancel'),
                   ),
-                  _ => SizedBox(
-                    height: 32,
-                    width: 32,
-                    child: CircularProgressIndicator(value: indicatorValue),
-                  ),
-                },
-                const SizedBox(height: 16.0),
-                Text(
-                  progressText,
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    color: Colors.white,
-                  ),
-                ),
-                const SizedBox(height: 20.0),
-                ElevatedButton.icon(
-                  onPressed: onCancel,
-                  icon: Icon(isDone ? Icons.close : Icons.cancel),
-                  label: Text(isDone ? 'Close' : 'Cancel'),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
   }
 }

--- a/packages/plugins/pdf/pubspec.yaml
+++ b/packages/plugins/pdf/pubspec.yaml
@@ -13,14 +13,14 @@ dependencies:
     sdk: flutter
   file_saver: ^0.4.0
   pdf: ^3.11.1
-  signals: ^6.2.0
-  signals_flutter: ^6.2.0
+  signals: ^7.1.0
+  signals_flutter: ^7.1.0
   superdeck: ^1.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   dart_code_metrics_presets: ^2.19.0
   google_fonts: ^8.1.0
   superdeck_core: ^1.0.0

--- a/packages/superdeck/lib/src/deck/navigation_input_listener.dart
+++ b/packages/superdeck/lib/src/deck/navigation_input_listener.dart
@@ -70,30 +70,32 @@ class _NavigationInputListenerState extends State<NavigationInputListener> {
     final size = MediaQuery.of(context).size;
     final presentation = DeckController.of(context).presentation;
 
-    return Watch((context) {
-      final isMenuOpen = presentation.isMenuOpen.value;
+    return SignalBuilder(
+      builder: (context) {
+        final isMenuOpen = presentation.isMenuOpen.value;
 
-      return GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onTapUp: isMenuOpen
-            ? null
-            : (details) {
-                final event = _gestureHandler.handleTap(details, size);
-                _dispatch(presentation, event);
-              },
-        onHorizontalDragStart: isMenuOpen
-            ? null
-            : (details) {
-                _gestureHandler.handleDragStart(details);
-              },
-        onHorizontalDragEnd: isMenuOpen
-            ? null
-            : (details) {
-                final event = _gestureHandler.handleSwipe(details);
-                _dispatch(presentation, event);
-              },
-        child: widget.child,
-      );
-    });
+        return GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTapUp: isMenuOpen
+              ? null
+              : (details) {
+                  final event = _gestureHandler.handleTap(details, size);
+                  _dispatch(presentation, event);
+                },
+          onHorizontalDragStart: isMenuOpen
+              ? null
+              : (details) {
+                  _gestureHandler.handleDragStart(details);
+                },
+          onHorizontalDragEnd: isMenuOpen
+              ? null
+              : (details) {
+                  final event = _gestureHandler.handleSwipe(details);
+                  _dispatch(presentation, event);
+                },
+          child: widget.child,
+        );
+      },
+    );
   }
 }

--- a/packages/superdeck/lib/src/deck/slide_page_content.dart
+++ b/packages/superdeck/lib/src/deck/slide_page_content.dart
@@ -20,37 +20,39 @@ class SlidePageContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final deckController = DeckController.of(context);
 
-    // Use Watch to react to signals
-    return Watch((context) {
-      // Access deck controller state
-      final session = deckController.session;
-      final isLoading = session.isLoading.value;
-      final hasError = session.hasFatalError.value;
-      final slides = deckController.slides.value;
+    // Use SignalBuilder to react to signals
+    return SignalBuilder(
+      builder: (context) {
+        // Access deck controller state
+        final session = deckController.session;
+        final isLoading = session.isLoading.value;
+        final hasError = session.hasFatalError.value;
+        final slides = deckController.slides.value;
 
-      // Render appropriate state
-      if (hasError) {
-        return _ErrorScreen(
-          error: session.error.value,
-          onRetry: deckController.reloadDeck,
+        // Render appropriate state
+        if (hasError) {
+          return _ErrorScreen(
+            error: session.error.value,
+            onRetry: deckController.reloadDeck,
+          );
+        }
+
+        if (isLoading) {
+          return const _LoadingScreen();
+        }
+
+        if (slides.isEmpty) {
+          return const _NoSlidesScreen();
+        }
+
+        final safeIndex = index.clamp(0, slides.length - 1);
+        return Semantics(
+          label: 'Slide ${safeIndex + 1}',
+          container: true,
+          child: SlideScreen(slides[safeIndex]),
         );
-      }
-
-      if (isLoading) {
-        return const _LoadingScreen();
-      }
-
-      if (slides.isEmpty) {
-        return const _NoSlidesScreen();
-      }
-
-      final safeIndex = index.clamp(0, slides.length - 1);
-      return Semantics(
-        label: 'Slide ${safeIndex + 1}',
-        container: true,
-        child: SlideScreen(slides[safeIndex]),
-      );
-    });
+      },
+    );
   }
 }
 

--- a/packages/superdeck/lib/src/rendering/slides/slide_thumbnail.dart
+++ b/packages/superdeck/lib/src/rendering/slides/slide_thumbnail.dart
@@ -21,34 +21,36 @@ class SlideThumbnail extends StatelessWidget {
   Widget build(BuildContext context) {
     final presentation = DeckController.of(context).presentation;
 
-    return Watch((context) {
-      final asyncThumbnail = presentation.getThumbnail(slide.key);
+    return SignalBuilder(
+      builder: (context) {
+        final asyncThumbnail = presentation.getThumbnail(slide.key);
 
-      if (asyncThumbnail == null) {
+        if (asyncThumbnail == null) {
+          return _PreviewContainer(
+            selected: selected,
+            child: AspectRatio(
+              aspectRatio: kAspectRatio,
+              child: Container(
+                color: Colors.grey[300],
+                child: const Center(child: IsometricLoading()),
+              ),
+            ),
+          );
+        }
+
         return _PreviewContainer(
           selected: selected,
-          child: AspectRatio(
-            aspectRatio: kAspectRatio,
-            child: Container(
-              color: Colors.grey[300],
-              child: const Center(child: IsometricLoading()),
-            ),
+          child: Stack(
+            children: [
+              AspectRatio(
+                aspectRatio: kAspectRatio,
+                child: asyncThumbnail.build(context),
+              ),
+            ],
           ),
         );
-      }
-
-      return _PreviewContainer(
-        selected: selected,
-        child: Stack(
-          children: [
-            AspectRatio(
-              aspectRatio: kAspectRatio,
-              child: asyncThumbnail.build(context),
-            ),
-          ],
-        ),
-      );
-    });
+      },
+    );
   }
 }
 

--- a/packages/superdeck/lib/src/thumbnails/async_thumbnail.dart
+++ b/packages/superdeck/lib/src/thumbnails/async_thumbnail.dart
@@ -128,14 +128,16 @@ class AsyncThumbnail {
   }
 
   Widget build(BuildContext context) {
-    return Watch((context) {
-      return switch (_status.value) {
-        AsyncFileStatus.idle => const IsometricLoading(),
-        AsyncFileStatus.loading => const IsometricLoading(),
-        AsyncFileStatus.done => _buildLoadedImage(context),
-        AsyncFileStatus.error => _errorWidget(context, this),
-      };
-    });
+    return SignalBuilder(
+      builder: (context) {
+        return switch (_status.value) {
+          AsyncFileStatus.idle => const IsometricLoading(),
+          AsyncFileStatus.loading => const IsometricLoading(),
+          AsyncFileStatus.done => _buildLoadedImage(context),
+          AsyncFileStatus.error => _errorWidget(context, this),
+        };
+      },
+    );
   }
 
   Widget _buildLoadedImage(BuildContext context) {

--- a/packages/superdeck/lib/src/ui/app_shell.dart
+++ b/packages/superdeck/lib/src/ui/app_shell.dart
@@ -195,50 +195,54 @@ class _SplitViewState extends State<SplitView>
     final deck = DeckController.of(context);
     final presentation = deck.presentation;
 
-    return Watch((context) {
-      final isNotesOpen = presentation.isNotesOpen.value;
-      final slides = deck.slides.value;
-      final currentSlide = presentation.currentSlide.value;
+    return SignalBuilder(
+      builder: (context) {
+        final isNotesOpen = presentation.isNotesOpen.value;
+        final slides = deck.slides.value;
+        final currentSlide = presentation.currentSlide.value;
 
-      /// Common content for thumbnails
-      final thumbnailPanel = ThumbnailPanel(
-        scrollDirection: widget.isSmallLayout ? Axis.horizontal : Axis.vertical,
-        onItemTap: presentation.goToSlide,
-        activeIndex:
-            currentSlide?.slideIndex ?? presentation.currentIndex.value,
-        itemBuilder: (index, selected) {
-          return SlideThumbnail(selected: selected, slide: slides[index]);
-        },
-        itemCount: slides.length,
-      );
-
-      /// Comments panel (shown only if notes are open)
-      final commentsPanel = isNotesOpen
-          ? CommentsPanel(comments: currentSlide?.comments ?? [])
-          : const SizedBox();
-
-      // For small layout, show the panel horizontally (i.e., row) if it's at the BOTTOM,
-      // or for a big layout, we might do a column if it's on the SIDE.
-      // This is somewhat reversed based on your preference, so adjust as needed.
-      if (widget.isSmallLayout) {
-        // Panel at bottom => put them side-by-side in a Row
-        return Row(
-          children: [
-            !isNotesOpen
-                ? Expanded(child: thumbnailPanel)
-                : Expanded(child: commentsPanel),
-          ],
+        /// Common content for thumbnails
+        final thumbnailPanel = ThumbnailPanel(
+          scrollDirection: widget.isSmallLayout
+              ? Axis.horizontal
+              : Axis.vertical,
+          onItemTap: presentation.goToSlide,
+          activeIndex:
+              currentSlide?.slideIndex ?? presentation.currentIndex.value,
+          itemBuilder: (index, selected) {
+            return SlideThumbnail(selected: selected, slide: slides[index]);
+          },
+          itemCount: slides.length,
         );
-      } else {
-        // Panel on the side => put them in a Column
-        return Column(
-          children: [
-            Expanded(flex: 3, child: thumbnailPanel),
-            if (isNotesOpen) Expanded(flex: 1, child: commentsPanel),
-          ],
-        );
-      }
-    });
+
+        /// Comments panel (shown only if notes are open)
+        final commentsPanel = isNotesOpen
+            ? CommentsPanel(comments: currentSlide?.comments ?? [])
+            : const SizedBox();
+
+        // For small layout, show the panel horizontally (i.e., row) if it's at the BOTTOM,
+        // or for a big layout, we might do a column if it's on the SIDE.
+        // This is somewhat reversed based on your preference, so adjust as needed.
+        if (widget.isSmallLayout) {
+          // Panel at bottom => put them side-by-side in a Row
+          return Row(
+            children: [
+              !isNotesOpen
+                  ? Expanded(child: thumbnailPanel)
+                  : Expanded(child: commentsPanel),
+            ],
+          );
+        } else {
+          // Panel on the side => put them in a Column
+          return Column(
+            children: [
+              Expanded(flex: 3, child: thumbnailPanel),
+              if (isNotesOpen) Expanded(flex: 1, child: commentsPanel),
+            ],
+          );
+        }
+      },
+    );
   }
 
   Widget? _buildFloatingAction({
@@ -263,141 +267,144 @@ class _SplitViewState extends State<SplitView>
     // For small layout, the panel is typically at the bottom (vertical),
     // so we place it in a Column below the main content.
     // For regular layout, place it on the left in a Row.
-    return Watch((context) {
-      final isMenuOpen = deckController.presentation.isMenuOpen.value;
-      final isBuildActive = deckController.session.isBuildActive.value;
-      final buildFailure = deckController.session.buildFailure.value;
+    return SignalBuilder(
+      builder: (context) {
+        final isMenuOpen = deckController.presentation.isMenuOpen.value;
+        final isBuildActive = deckController.session.isBuildActive.value;
+        final buildFailure = deckController.session.buildFailure.value;
 
-      return Scaffold(
-        backgroundColor: const Color.fromARGB(255, 9, 9, 9),
-        floatingActionButtonLocation: FloatingActionButtonLocation.miniEndFloat,
-        floatingActionButton: _buildFloatingAction(
-          deckController: deckController,
-          isMenuOpen: isMenuOpen,
-        ),
+        return Scaffold(
+          backgroundColor: const Color.fromARGB(255, 9, 9, 9),
+          floatingActionButtonLocation:
+              FloatingActionButtonLocation.miniEndFloat,
+          floatingActionButton: _buildFloatingAction(
+            deckController: deckController,
+            isMenuOpen: isMenuOpen,
+          ),
 
-        bottomNavigationBar: SizeTransition(
-          axis: Axis.vertical,
-          sizeFactor: _curvedAnimation,
-          child: DeckBottomBar(actions: widget.actions),
-        ),
+          bottomNavigationBar: SizeTransition(
+            axis: Axis.vertical,
+            sizeFactor: _curvedAnimation,
+            child: DeckBottomBar(actions: widget.actions),
+          ),
 
-        // Body changes layout based on [isSmallLayout].
-        body: Stack(
-          children: [
-            widget.isSmallLayout
-                ? Column(
-                    children: [
-                      // Main slide content
-                      Expanded(
-                        child: Center(
-                          child: ScaledWidget(
-                            targetSize: kResolution,
-                            child: widget.child,
+          // Body changes layout based on [isSmallLayout].
+          body: Stack(
+            children: [
+              widget.isSmallLayout
+                  ? Column(
+                      children: [
+                        // Main slide content
+                        Expanded(
+                          child: Center(
+                            child: ScaledWidget(
+                              targetSize: kResolution,
+                              child: widget.child,
+                            ),
                           ),
                         ),
-                      ),
-                      // Animated bottom panel
-                      SizeTransition(
-                        axis: Axis.vertical,
-                        sizeFactor: _curvedAnimation,
-                        child: SizedBox(
-                          height: 200,
-                          child: _buildPanel(context),
-                        ),
-                      ),
-                    ],
-                  )
-                : Row(
-                    children: [
-                      // Animated side panel
-                      SizeTransition(
-                        axis: Axis.horizontal,
-                        sizeFactor: _curvedAnimation,
-                        child: SizedBox(
-                          width: 300,
-                          child: _buildPanel(context),
-                        ),
-                      ),
-                      // Main slide content
-                      Expanded(
-                        child: Center(
-                          child: ScaledWidget(
-                            targetSize: kResolution,
-                            child: widget.child,
+                        // Animated bottom panel
+                        SizeTransition(
+                          axis: Axis.vertical,
+                          sizeFactor: _curvedAnimation,
+                          child: SizedBox(
+                            height: 200,
+                            child: _buildPanel(context),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-            if (isBuildActive || buildFailure != null)
-              Positioned(
-                top: 16,
-                right: 16,
-                child: Container(
-                  constraints: const BoxConstraints(maxWidth: 320),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 8,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.black87,
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(
-                      color: buildFailure == null
-                          ? Colors.white24
-                          : Colors.redAccent.withValues(alpha: 0.8),
-                      width: 1,
+                      ],
+                    )
+                  : Row(
+                      children: [
+                        // Animated side panel
+                        SizeTransition(
+                          axis: Axis.horizontal,
+                          sizeFactor: _curvedAnimation,
+                          child: SizedBox(
+                            width: 300,
+                            child: _buildPanel(context),
+                          ),
+                        ),
+                        // Main slide content
+                        Expanded(
+                          child: Center(
+                            child: ScaledWidget(
+                              targetSize: kResolution,
+                              child: widget.child,
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
+              if (isBuildActive || buildFailure != null)
+                Positioned(
+                  top: 16,
+                  right: 16,
+                  child: Container(
+                    constraints: const BoxConstraints(maxWidth: 320),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.black87,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: buildFailure == null
+                            ? Colors.white24
+                            : Colors.redAccent.withValues(alpha: 0.8),
+                        width: 1,
+                      ),
+                    ),
+                    child: isBuildActive
+                        ? const Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: IsometricLoading(),
+                              ),
+                              SizedBox(width: 8),
+                              Text(
+                                'Rebuilding...',
+                                style: TextStyle(
+                                  color: Colors.white70,
+                                  fontSize: 12,
+                                ),
+                              ),
+                            ],
+                          )
+                        : Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Text(
+                                'Build failed',
+                                style: TextStyle(
+                                  color: Colors.redAccent,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                buildFailure!.message,
+                                maxLines: 3,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  color: Colors.white70,
+                                  fontSize: 12,
+                                ),
+                              ),
+                            ],
+                          ),
                   ),
-                  child: isBuildActive
-                      ? const Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: IsometricLoading(),
-                            ),
-                            SizedBox(width: 8),
-                            Text(
-                              'Rebuilding...',
-                              style: TextStyle(
-                                color: Colors.white70,
-                                fontSize: 12,
-                              ),
-                            ),
-                          ],
-                        )
-                      : Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Text(
-                              'Build failed',
-                              style: TextStyle(
-                                color: Colors.redAccent,
-                                fontSize: 12,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              buildFailure!.message,
-                              maxLines: 3,
-                              overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(
-                                color: Colors.white70,
-                                fontSize: 12,
-                              ),
-                            ),
-                          ],
-                        ),
                 ),
-              ),
-          ],
-        ),
-      );
-    });
+            ],
+          ),
+        );
+      },
+    );
   }
 }

--- a/packages/superdeck/lib/src/ui/deck_presenter.dart
+++ b/packages/superdeck/lib/src/ui/deck_presenter.dart
@@ -49,17 +49,19 @@ class DeckPresenter extends StatelessWidget {
             // so render the current slide reactively and cross-fade between
             // indices to match SuperDeckApp's route transition. (A nested Router
             // would fight the host app's own router for platform route info.)
-            child: Watch((context) {
-              final index = controller.presentation.currentIndex.value;
-              return AnimatedSwitcher(
-                duration: const Duration(milliseconds: 400),
-                switchInCurve: Curves.easeInOut,
-                child: KeyedSubtree(
-                  key: ValueKey<int>(index),
-                  child: SlidePageContent(index: index),
-                ),
-              );
-            }),
+            child: SignalBuilder(
+              builder: (context) {
+                final index = controller.presentation.currentIndex.value;
+                return AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 400),
+                  switchInCurve: Curves.easeInOut,
+                  child: KeyedSubtree(
+                    key: ValueKey<int>(index),
+                    child: SlidePageContent(index: index),
+                  ),
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/packages/superdeck/lib/src/ui/deck_shell_modal.dart
+++ b/packages/superdeck/lib/src/ui/deck_shell_modal.dart
@@ -106,8 +106,8 @@ class _DeckShellModalHostState extends State<DeckShellModalHost> {
   Widget build(BuildContext context) {
     return _DeckShellModalScope(
       controller: _controller,
-      child: Watch(
-        (context) => Stack(
+      child: SignalBuilder(
+        builder: (context) => Stack(
           fit: StackFit.expand,
           children: [
             widget.child,

--- a/packages/superdeck/lib/src/ui/panels/bottom_bar.dart
+++ b/packages/superdeck/lib/src/ui/panels/bottom_bar.dart
@@ -34,9 +34,9 @@ class DeckBottomBar extends StatelessWidget {
     return FlexBox(
       style: _bottomBarContainer,
       children: [
-        // view notes - use Watch for reactive icon
-        Watch(
-          (context) => SDIconButton(
+        // view notes - use SignalBuilder for reactive icon
+        SignalBuilder(
+          builder: (context) => SDIconButton(
             onPressed: presentation.toggleNotes,
             icon: presentation.isNotesOpen.value
                 ? Icons.comment
@@ -75,9 +75,9 @@ class DeckBottomBar extends StatelessWidget {
         ),
         const Spacer(),
 
-        // Page counter - use Watch for reactive text
-        Watch(
-          (context) => Text(
+        // Page counter - use SignalBuilder for reactive text
+        SignalBuilder(
+          builder: (context) => Text(
             '${presentation.currentIndex.value + 1} of ${presentation.totalSlides.value}',
             style: const TextStyle(color: Colors.white),
           ),

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
   collection: ^1.18.0
   dart_mappable: ^4.7.0
   path: ^1.9.0
-  syntax_highlight: ^0.4.0
+  syntax_highlight: ^0.5.0
   scrollable_positioned_list: ^0.3.8
-  go_router: ^14.2.7
+  go_router: ^17.3.0
   path_provider: ^2.1.4
   mix: ^2.1.0
   remix: ^0.2.0
@@ -32,14 +32,14 @@ dependencies:
   google_fonts: ^8.1.0
   meta: ^1.16.0
   qr_flutter: ^4.1.0
-  signals: ^6.2.0
-  signals_flutter: ^6.2.0
+  signals: ^7.1.0
+  signals_flutter: ^7.1.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   custom_lint: ^0.8.1
   dart_code_metrics_presets: ^2.19.0
   build_runner: ^2.5.4


### PR DESCRIPTION
Updates `ack`, `go_router`, `signals`/`signals_flutter`, `lints`/`flutter_lints`, `syntax_highlight`, `mesh`, `googleai_dart`, and `google_cloud_ai_generativelanguage_v1beta` to their latest versions across `core`, `superdeck`, `superdeck_pdf`, `playground`, and `demo`. Migrates off signals v7's deprecated `Watch` widget and `.watch(context)` extension to `SignalBuilder`/`SignalWidget` in `superdeck`, `superdeck_pdf`, and `playground`, and centralizes the `ack`/`mix`/`remix` version pins in `melos.yaml` so `melos bootstrap` keeps them in sync. `naked_ui` stays on `0.2.0-beta.7` since `remix` 0.2.0 (its latest release) still constrains it there.

## Test plan
- [x] `melos run analyze` (dart analyze + DCM) — clean across all 8 packages
- [x] `melos run test` — all 8 packages passing
- [x] `melos run build_runner:build` — no generated-file drift