### PR TITLE
Add cached WebView builtin

### DIFF
--- a/docs/guides/custom-widgets.mdx
+++ b/docs/guides/custom-widgets.mdx
@@ -160,5 +160,5 @@ Widget twitterWidget(Map<String, Object?> args) {
 
 ## Notes
 
-- Built-in widgets (`image`, `dartpad`, `qrcode`) are always available
+- Built-in widgets (`image`, `dartpad`, `webview`, `qrcode`) are always available
 - Override built-in widgets by registering the same name

--- a/docs/guides/markdown-authoring.mdx
+++ b/docs/guides/markdown-authoring.mdx
@@ -133,6 +133,22 @@ For all `@dartpad` arguments, see the [Markdown syntax reference](../reference/m
 
 > DartPad uses an embedded WebView. Make sure your target platform supports WebViews.
 
+### `@webview`
+
+Embed a persistent web page. Controllers are cached per block (or `cacheKey`) so
+returning to a slide does not reload the page. Reuse is sequential (one live
+mount at a time), not concurrent multi-widget sharing.
+
+````markdown
+@webview {
+  url: "https://example.com"
+  title: "Example"
+  showControls: true
+}
+````
+
+For all `@webview` arguments, see the [Markdown syntax reference](../reference/markdown-syntax).
+
 ### Custom widgets
 
 Register widgets in `DeckOptions.widgets`, then use them with the shorthand syntax:

--- a/docs/guides/superdeck-overview.mdx
+++ b/docs/guides/superdeck-overview.mdx
@@ -56,6 +56,7 @@ Build presentations with Markdown and Flutter
 
 - `image` – images with fit options (`cover`, `contain`, `fill`, `fitWidth`, `fitHeight`)
 - `dartpad` – embedded DartPad snippets with live editing
+- `webview` – embed a persistent web page with optional controls
 - `qrcode` – generate QR codes
 
 **Alignment options**: `topLeft`, `topCenter`, `topRight`, `centerLeft`, `center`, `centerRight`, `bottomLeft`, `bottomCenter`, `bottomRight`

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -25,7 +25,7 @@ SuperDeck is a Flutter presentation framework that combines Markdown simplicity 
 ## Core features
 
 - **3 Block Types** - `@block` (content), `@section` (layout), `@widget` (custom components)
-- **Built-in Widgets** - `image`, `dartpad`, `qrcode`
+- **Built-in Widgets** - `image`, `dartpad`, `webview`, `qrcode`
 - **CLI Commands** - `setup`, `build`, `version`
 - **Markdown Support** - Full CommonMark with GitHub-style alerts
 - **Custom Widgets** - Extensible widget system

--- a/docs/reference/block-types.mdx
+++ b/docs/reference/block-types.mdx
@@ -5,7 +5,7 @@ description: Complete reference for all SuperDeck block types and their properti
 
 # Block types reference
 
-SuperDeck has 3 core block types. Built-in widgets (`image`, `dartpad`, `qrcode`) use the same widget system as `@widget`.
+SuperDeck has 3 core block types. Built-in widgets (`image`, `dartpad`, `webview`, `qrcode`) use the same widget system as `@widget`.
 
 ## Common block properties
 
@@ -173,6 +173,25 @@ Use shorthand syntax for these widgets.
 - `theme` - `light` or `dark` (default: `light`)
 - `embed` - Embed mode (default: `true`)
 - `run` - Auto-run code (default: `true`)
+- `cacheKey` - Optional key for sequential controller reuse across remounts (not concurrent mounts)
+
+### webview
+
+```markdown
+@webview {
+  url: "https://example.com"
+  title: "Example"
+  showControls: true
+}
+```
+
+**Properties:**
+- `url` (required) - Absolute `http` or `https` URL
+- `cacheKey` - Optional key for sequential controller reuse across remounts (not concurrent mounts)
+- `title` - Label shown during static/thumbnail capture
+- `allowedHosts` - Navigation allowlist (default: source host only)
+- `showControls` - Show refresh control (default: `false`)
+- `javascript` - Enable JavaScript (default: `true`)
 
 ### qrcode
 

--- a/docs/reference/markdown-syntax.mdx
+++ b/docs/reference/markdown-syntax.mdx
@@ -38,7 +38,7 @@ SuperDeck supports three core block types.
 | `@block` | Render markdown content | `flex`, `align`, `scrollable` |
 | `@widget` | Embed custom Flutter widgets | `name`, `flex`, `align`, `scrollable` + custom args |
 
-Built-in widgets (`image`, `dartpad`, `qrcode`) use the same widget syntax as `@widget`.
+Built-in widgets (`image`, `dartpad`, `webview`, `qrcode`) use the same widget syntax as `@widget`.
 
 ## Common block properties
 
@@ -100,6 +100,28 @@ Arguments:
 - `theme`: `light` or `dark`.
 - `embed`: boolean.
 - `run`: boolean.
+- `cacheKey`: optional key for sequential controller reuse across remounts (not concurrent mounts).
+
+### `@webview`
+
+Example:
+
+````markdown
+@webview {
+  url: "https://example.com"
+  title: "Example"
+  showControls: true
+}
+````
+
+Arguments:
+
+- `url` (required): absolute `http` or `https` URL.
+- `cacheKey`: optional key for sequential controller reuse across remounts (not concurrent mounts).
+- `title`: label shown during static/thumbnail capture.
+- `allowedHosts`: navigation allowlist (default: source host only).
+- `showControls`: show refresh control (default: `false`).
+- `javascript`: enable JavaScript (default: `true`).
 
 ### `@qrcode`
 

--- a/packages/superdeck/lib/src/builtins/dartpad_widget.dart
+++ b/packages/superdeck/lib/src/builtins/dartpad_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 
 import '../rendering/blocks/block_provider.dart';
@@ -14,11 +14,14 @@ class DartPadDto {
 
   final bool run;
 
+  final String? cacheKey;
+
   const DartPadDto({
     required this.id,
     this.theme,
     this.embed = true,
     this.run = true,
+    this.cacheKey,
   });
 
   /// Schema for validating DartPad arguments.
@@ -27,6 +30,7 @@ class DartPadDto {
     'theme': DartPadTheme.schema.nullable().optional(),
     'embed': Ack.boolean().nullable().optional(),
     'run': Ack.boolean().nullable().optional(),
+    'cacheKey': Ack.string().nullable().optional(),
   });
 
   /// Parses and validates raw map into typed DartPadDto.
@@ -42,6 +46,7 @@ class DartPadDto {
       theme: theme,
       embed: map['embed'] as bool? ?? true,
       run: map['run'] as bool? ?? true,
+      cacheKey: map['cacheKey'] as String?,
     );
   }
 
@@ -74,6 +79,7 @@ class DartPadDto {
 /// - `theme` (optional): Theme name (light, dark) - default: light
 /// - `embed` (optional): Whether to embed - default: true
 /// - `run` (optional): Whether to auto-run - default: true
+/// - `cacheKey` (optional): Sequential controller reuse across remounts
 class DartPadWidget extends StatelessWidget {
   final DartPadDto _data;
 
@@ -83,6 +89,14 @@ class DartPadWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final data = BlockConfiguration.of(context);
-    return WebViewWrapper(size: data.size, url: _data.toUrl());
+    return WebViewWrapper(
+      size: data.size,
+      url: _data.toUrl(),
+      cacheKey: _data.cacheKey,
+      title: 'DartPad',
+      showControls: true,
+      showClearControl: true,
+      javascript: true,
+    );
   }
 }

--- a/packages/superdeck/lib/src/builtins/webview_widget.dart
+++ b/packages/superdeck/lib/src/builtins/webview_widget.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/widgets.dart';
+import 'package:superdeck_core/superdeck_core.dart';
+
+import '../rendering/blocks/block_provider.dart';
+import '../ui/widgets/webview_wrapper.dart';
+
+/// Strongly-typed data transfer object for the webview widget.
+class WebViewDto {
+  final String url;
+  final String? cacheKey;
+  final String? title;
+  final List<String>? allowedHosts;
+  final bool showControls;
+  final bool javascript;
+
+  const WebViewDto({
+    required this.url,
+    this.cacheKey,
+    this.title,
+    this.allowedHosts,
+    this.showControls = false,
+    this.javascript = true,
+  });
+
+  /// Schema for validating webview arguments.
+  static final schema = Ack.object({
+    'url': Ack.string().notEmpty(),
+    'cacheKey': Ack.string().nullable().optional(),
+    'title': Ack.string().nullable().optional(),
+    'allowedHosts': Ack.list(Ack.string()).nullable().optional(),
+    'showControls': Ack.boolean().nullable().optional(),
+    'javascript': Ack.boolean().nullable().optional(),
+  });
+
+  /// Parses and validates raw map into typed [WebViewDto].
+  static WebViewDto parse(Map<String, Object?> map) {
+    schema.parse(map);
+
+    final rawUrl = map['url'];
+    if (rawUrl is! String) {
+      throw const FormatException('WebView widget requires a string "url".');
+    }
+    final url = rawUrl.trim();
+    _validateAbsoluteHttpUrl(url);
+
+    final rawHosts = map['allowedHosts'];
+    List<String>? allowedHosts;
+    if (rawHosts is List) {
+      allowedHosts = rawHosts.map((host) => host.toString()).toList();
+    }
+
+    return WebViewDto(
+      url: url,
+      cacheKey: map['cacheKey'] as String?,
+      title: map['title'] as String?,
+      allowedHosts: allowedHosts,
+      showControls: map['showControls'] as bool? ?? false,
+      javascript: map['javascript'] as bool? ?? true,
+    );
+  }
+
+  static void _validateAbsoluteHttpUrl(String url) {
+    final uri = Uri.tryParse(url);
+    if (uri == null ||
+        !uri.hasScheme ||
+        (uri.scheme != 'http' && uri.scheme != 'https') ||
+        uri.host.isEmpty) {
+      throw FormatException(
+        'WebView "url" must be an absolute http or https URL, got: "$url".',
+      );
+    }
+  }
+}
+
+/// Built-in widget for embedding a persistent web page in slides.
+///
+/// Usage in markdown:
+/// ```markdown
+/// @webview {
+///   url: https://example.com
+///   title: Example
+///   showControls: true
+/// }
+/// ```
+///
+/// Parameters:
+/// - `url` (required): Absolute `http`/`https` URL
+/// - `cacheKey` (optional): Sequential controller reuse across remounts
+/// - `title` (optional): Label shown during static/thumbnail capture
+/// - `allowedHosts` (optional): Navigation allowlist (default: source host)
+/// - `showControls` (optional): Show refresh control (default: false)
+/// - `javascript` (optional): Enable JavaScript (default: true)
+class WebViewWidget extends StatelessWidget {
+  final WebViewDto _data;
+
+  WebViewWidget(Map<String, Object?> args, {super.key})
+    : _data = WebViewDto.parse(args);
+
+  @override
+  Widget build(BuildContext context) {
+    final data = BlockConfiguration.of(context);
+    return WebViewWrapper(
+      size: data.size,
+      url: _data.url,
+      cacheKey: _data.cacheKey,
+      title: _data.title,
+      allowedHosts: _data.allowedHosts,
+      showControls: _data.showControls,
+      javascript: _data.javascript,
+    );
+  }
+}

--- a/packages/superdeck/lib/src/builtins/widgets.dart
+++ b/packages/superdeck/lib/src/builtins/widgets.dart
@@ -2,18 +2,21 @@ import '../deck/widget_factory.dart';
 import 'dartpad_widget.dart';
 import 'image_widget.dart';
 import 'qr_code_widget.dart';
+import 'webview_widget.dart';
 
 /// Map of built-in widget factories.
 ///
 /// These widgets are automatically available in all presentations:
 /// - `image`: Display images with various fit options
 /// - `dartpad`: Embed DartPad code editors
+/// - `webview`: Embed a persistent web page
 /// - `qrcode`: Generate QR codes
 ///
 /// Built-in widgets are registered by default but can be overridden
 /// by user-provided widgets with the same name.
-final Map<String, WidgetFactory> builtInWidgets = {
+final builtInWidgets = <String, WidgetFactory>{
   'image': ImageWidget.new,
   'dartpad': DartPadWidget.new,
+  'webview': WebViewWidget.new,
   'qrcode': QrCodeWidget.new,
 };

--- a/packages/superdeck/lib/src/deck/deck_controller.dart
+++ b/packages/superdeck/lib/src/deck/deck_controller.dart
@@ -4,6 +4,7 @@ import 'package:superdeck_core/superdeck_core.dart';
 
 import '../thumbnails/thumbnail_service.dart';
 import '../ui/widgets/provider.dart';
+import '../ui/widgets/webview_controller_cache.dart';
 import '../utils/asset_cache_store.dart';
 import 'deck_options.dart';
 import 'deck_presentation_state.dart';
@@ -28,7 +29,8 @@ final class DeckController {
     session = DeckSessionState(deckLoader: deckLoader);
     presentation = DeckPresentationState(
       thumbnailService:
-          thumbnailService ?? ThumbnailService(cacheStore: this.assetCacheStore),
+          thumbnailService ??
+          ThumbnailService(cacheStore: this.assetCacheStore),
       slides: slides,
       transitionDuration: transitionDuration,
     );
@@ -36,6 +38,10 @@ final class DeckController {
 
   /// Asset cache shared by thumbnail capture and in-slide image resolution.
   late final AssetCacheStore assetCacheStore;
+
+  /// Deck-scoped WebView controllers reused across slide remounts.
+  final webViewControllerCache = WebViewControllerCache();
+
   late final Signal<DeckOptions> options;
   late final DeckSessionState session;
   late final DeckPresentationState presentation;
@@ -53,6 +59,7 @@ final class DeckController {
   Future<void> reloadDeck() => session.reload();
 
   void dispose() {
+    webViewControllerCache.clear();
     presentation.dispose();
     session.dispose();
     options.dispose();

--- a/packages/superdeck/lib/src/rendering/blocks/block_provider.dart
+++ b/packages/superdeck/lib/src/rendering/blocks/block_provider.dart
@@ -4,27 +4,40 @@ import 'package:superdeck_core/superdeck_core.dart';
 import '../../styling/components/slide.dart';
 import '../../ui/widgets/provider.dart';
 
+/// Stable identity for a block within a slide tree.
+///
+/// Used as the default WebView cache key so remounts of the same block reuse
+/// a controller without sharing across unrelated blocks by URL alone.
+String buildBlockRuntimeKey(String slideKey, int sectionIndex, int blockIndex) {
+  return '$slideKey:s$sectionIndex:b$blockIndex';
+}
+
 class BlockConfiguration {
   const BlockConfiguration({
     required this.spec,
     required this.size,
     required this.align,
+    required this.runtimeKey,
   });
 
   final SlideSpec spec;
   final Size size;
   final ContentAlignment? align;
 
+  /// Slide-local identity derived from slide key + section/block indices.
+  final String runtimeKey;
+
   @override
   bool operator ==(Object other) {
     return other is BlockConfiguration &&
         other.spec == spec &&
         other.size == size &&
-        other.align == align;
+        other.align == align &&
+        other.runtimeKey == runtimeKey;
   }
 
   @override
-  int get hashCode => spec.hashCode ^ size.hashCode ^ align.hashCode;
+  int get hashCode => Object.hash(spec, size, align, runtimeKey);
 
   static BlockConfiguration of(BuildContext context) {
     final data = InheritedData.maybeOf<BlockConfiguration>(context);

--- a/packages/superdeck/lib/src/rendering/blocks/block_widget.dart
+++ b/packages/superdeck/lib/src/rendering/blocks/block_widget.dart
@@ -22,12 +22,14 @@ class _BlockContainer extends StatefulWidget {
     required this.block,
     required this.size,
     required this.configuration,
+    required this.runtimeKey,
     required this.child,
   });
 
   final Block block;
   final Size size;
   final SlideConfiguration configuration;
+  final String runtimeKey;
   final Widget child;
 
   @override
@@ -49,6 +51,7 @@ class _BlockContainerState extends State<_BlockContainer> {
         math.max(0.0, widget.size.width - blockOffset.dx),
         math.max(0.0, widget.size.height - blockOffset.dy),
       ),
+      runtimeKey: widget.runtimeKey,
     );
 
     Widget content = InheritedData(
@@ -164,11 +167,13 @@ class BlockWidget extends StatelessWidget {
     required this.block,
     required this.size,
     required this.configuration,
+    required this.runtimeKey,
   });
 
   final ContentBlock block;
   final Size size;
   final SlideConfiguration configuration;
+  final String runtimeKey;
 
   @override
   Widget build(BuildContext context) {
@@ -176,6 +181,7 @@ class BlockWidget extends StatelessWidget {
       block: block,
       size: size,
       configuration: configuration,
+      runtimeKey: runtimeKey,
       child: _ContentBlockChild(content: block.content),
     );
   }
@@ -188,11 +194,13 @@ class CustomBlockWidget extends StatelessWidget {
     required this.block,
     required this.size,
     required this.configuration,
+    required this.runtimeKey,
   });
 
   final WidgetBlock block;
   final Size size;
   final SlideConfiguration configuration;
+  final String runtimeKey;
 
   @override
   Widget build(BuildContext context) {
@@ -200,6 +208,7 @@ class CustomBlockWidget extends StatelessWidget {
       block: block,
       size: size,
       configuration: configuration,
+      runtimeKey: runtimeKey,
       child: _CustomBlockChild(block: block),
     );
   }
@@ -207,10 +216,16 @@ class CustomBlockWidget extends StatelessWidget {
 
 /// Section widget that layouts child blocks horizontally.
 class SectionWidget extends StatelessWidget {
-  const SectionWidget({super.key, required this.section, required this.size});
+  const SectionWidget({
+    super.key,
+    required this.section,
+    required this.size,
+    required this.sectionIndex,
+  });
 
   final SectionBlock section;
   final Size size;
+  final int sectionIndex;
 
   Positioned _renderDebugInfo(Block block, Size size) {
     const textStyle = TextStyle(color: Colors.black, fontSize: 12);
@@ -238,20 +253,28 @@ ${size.width.toStringAsFixed(2)} x ${size.height.toStringAsFixed(2)}''';
     double leftOffset = 0;
     final children = <Widget>[];
 
-    for (final block in section.blocks) {
+    for (var blockIndex = 0; blockIndex < section.blocks.length; blockIndex++) {
+      final block = section.blocks[blockIndex];
       final blockWidth = flexUnit * block.flex;
       final blockSize = Size(blockWidth, size.height);
+      final runtimeKey = buildBlockRuntimeKey(
+        configuration.key,
+        sectionIndex,
+        blockIndex,
+      );
 
       Widget blockWidget = switch (block) {
         WidgetBlock b => CustomBlockWidget(
           block: b,
           size: blockSize,
           configuration: configuration,
+          runtimeKey: runtimeKey,
         ),
         ContentBlock b => BlockWidget(
           block: b,
           size: blockSize,
           configuration: configuration,
+          runtimeKey: runtimeKey,
         ),
       };
 

--- a/packages/superdeck/lib/src/rendering/slides/slide_view.dart
+++ b/packages/superdeck/lib/src/rendering/slides/slide_view.dart
@@ -44,48 +44,37 @@ class SlideView extends StatelessWidget {
       (previous, section) => previous + section.flex,
     );
 
-    final sectionSizes = <SectionBlock, Size>{};
-
-    for (var section in sections) {
+    var topOffset = 0.0;
+    final sectionWidgets = <Widget>[];
+    for (var sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+      final section = sections[sectionIndex];
       final heightPercentage = section.flex / totalSectionsFlex;
       final sectionSize = Size(
         slideSize.width,
         slideSize.height * heightPercentage,
       );
-      sectionSizes[section] = sectionSize;
-    }
-
-    Offset currentOffset = Offset.zero;
-
-    Map<SectionBlock, Offset> sectionOffsets = {};
-
-    for (var section in sectionSizes.entries) {
-      final sectionOffset = Offset(0, currentOffset.dy);
-      sectionOffsets[section.key] = sectionOffset;
-      currentOffset = Offset(
-        currentOffset.dx,
-        currentOffset.dy + section.value.height,
-      );
-    }
-
-    return Stack(
-      children: sections.map((section) {
-        final sectionOffset = sectionOffsets[section]!;
-        final sectionSize = sectionSizes[section]!;
-        return Positioned(
-          left: sectionOffset.dx,
-          top: sectionOffset.dy,
+      sectionWidgets.add(
+        Positioned(
+          left: 0,
+          top: topOffset,
           width: sectionSize.width,
           height: sectionSize.height,
           child: Stack(
             children: [
-              SectionWidget(section: section, size: sectionSize),
+              SectionWidget(
+                section: section,
+                size: sectionSize,
+                sectionIndex: sectionIndex,
+              ),
               if (configuration.debug) _renderDebugInfo(section, sectionSize),
             ],
           ),
-        );
-      }).toList(),
-    );
+        ),
+      );
+      topOffset += sectionSize.height;
+    }
+
+    return Stack(children: sectionWidgets);
   }
 
   @override

--- a/packages/superdeck/lib/src/ui/widgets/webview_controller_cache.dart
+++ b/packages/superdeck/lib/src/ui/widgets/webview_controller_cache.dart
@@ -1,0 +1,79 @@
+import 'package:webview_flutter/webview_flutter.dart';
+
+/// Mutable navigation policy shared between a cached controller and the active
+/// [WebViewWrapper] mount so host rules stay current after URL changes.
+class WebViewNavigationPolicy {
+  Set<String> allowedHosts = {};
+
+  NavigationDecision decide(NavigationRequest request) {
+    final requestHost = Uri.tryParse(request.url)?.host;
+    if (requestHost != null && allowedHosts.contains(requestHost)) {
+      return NavigationDecision.navigate;
+    }
+    return NavigationDecision.prevent;
+  }
+}
+
+/// One cached [WebViewController] plus the last loaded URL and live callbacks.
+class CachedWebViewEntry {
+  final WebViewController controller;
+  final policy = WebViewNavigationPolicy();
+
+  /// Last URL successfully requested for this entry.
+  String? loadedUrl;
+
+  /// Active mount listens here for page-finished fade-in.
+  void Function()? onPageFinished;
+
+  Object? _activeMount;
+
+  CachedWebViewEntry({required this.controller});
+
+  bool activate(Object mount) {
+    if (_activeMount == null || identical(_activeMount, mount)) {
+      _activeMount = mount;
+      return true;
+    }
+    return false;
+  }
+
+  void release(Object mount) {
+    if (!identical(_activeMount, mount)) return;
+    _activeMount = null;
+    onPageFinished = null;
+  }
+}
+
+/// Deck-scoped store of [WebViewController] instances keyed by cache identity.
+///
+/// Controllers are reused across remounts so returning to a slide does not
+/// reload the page. A controller backs at most one live [WebViewWidget] at a
+/// time — use sequential remount reuse, not concurrent multi-widget mounts.
+/// Cleared when the owning deck is disposed.
+class WebViewControllerCache {
+  final _entries = <String, CachedWebViewEntry>{};
+
+  int get length => _entries.length;
+
+  bool contains(String key) => _entries.containsKey(key);
+
+  CachedWebViewEntry? operator [](String key) => _entries[key];
+
+  CachedWebViewEntry getOrCreate(
+    String key,
+    WebViewController Function() create,
+  ) {
+    return _entries.putIfAbsent(
+      key,
+      () => CachedWebViewEntry(controller: create()),
+    );
+  }
+
+  void clear() {
+    for (final entry in _entries.values) {
+      entry.onPageFinished = null;
+      entry._activeMount = null;
+    }
+    _entries.clear();
+  }
+}

--- a/packages/superdeck/lib/src/ui/widgets/webview_wrapper.dart
+++ b/packages/superdeck/lib/src/ui/widgets/webview_wrapper.dart
@@ -1,96 +1,244 @@
-import 'dart:convert' show jsonEncode;
+import 'dart:async' show FutureOr;
 
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart' show Icons;
 import 'package:flutter/widgets.dart';
-import 'icon_button.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+import '../../deck/deck_controller.dart';
+import '../../deck/slide_configuration.dart';
+import '../../rendering/blocks/block_provider.dart';
+import 'icon_button.dart';
+import 'webview_controller_cache.dart';
+
+/// Shared persistent WebView surface for built-ins (`@webview`, `@dartpad`).
+///
+/// Live mounts resolve a deck-scoped cache identity (explicit [cacheKey] or the
+/// block [BlockConfiguration.runtimeKey]) and reuse the controller across
+/// remounts. [loadRequest] runs only on first create or URL change.
+///
+/// [cacheKey] is for sequential reuse (leave a slide, return later), not for
+/// mounting the same controller in two widgets at once.
+///
+/// When [SlideConfiguration.isStaticRendering] is true, renders a placeholder
+/// and never creates a controller.
 class WebViewWrapper extends StatefulWidget {
   final String url;
   final Size size;
+  final String? cacheKey;
+  final String? title;
+  final List<String>? allowedHosts;
+  final bool showControls;
+  final bool javascript;
+  final bool showClearControl;
 
-  const WebViewWrapper({super.key, required this.url, required this.size});
+  const WebViewWrapper({
+    super.key,
+    required this.url,
+    required this.size,
+    this.cacheKey,
+    this.title,
+    this.allowedHosts,
+    this.showControls = false,
+    this.javascript = true,
+    this.showClearControl = false,
+  });
 
   @override
   State<WebViewWrapper> createState() => _WebViewWrapperState();
 }
 
-class _WebViewWrapperState extends State<WebViewWrapper>
-    with AutomaticKeepAliveClientMixin {
-  late WebViewController _controller;
+class _WebViewWrapperState extends State<WebViewWrapper> {
+  final _mountToken = Object();
+
+  WebViewController? _controller;
+  CachedWebViewEntry? _cachedEntry;
+  WebViewNavigationPolicy? _localPolicy;
   bool _hide = true;
 
   @override
-  bool get wantKeepAlive => true;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setNavigationDelegate(
-        NavigationDelegate(
-          onPageFinished: (String url) {
-            _showDartPad();
-          },
-          onNavigationRequest: (NavigationRequest request) {
-            final sourceHost = Uri.tryParse(widget.url)?.host;
-            if (sourceHost == null) {
-              debugPrint(
-                'WebViewWrapper: unable to parse host from "${widget.url}". '
-                'Blocking navigation to "${request.url}".',
-              );
-            }
-            final requestHost = Uri.tryParse(request.url)?.host;
-            if (sourceHost != null && requestHost == sourceHost) {
-              return NavigationDecision.navigate;
-            }
-            return NavigationDecision.prevent;
-          },
-        ),
-      );
-
-    _loadDartPad();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _bindController(previousUrl: widget.url);
   }
 
   @override
   void didUpdateWidget(WebViewWrapper oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.url != widget.url) {
-      setState(() {
-        _hide = true;
-      });
-      _loadDartPad();
+    final propsChanged =
+        oldWidget.url != widget.url ||
+        oldWidget.cacheKey != widget.cacheKey ||
+        oldWidget.javascript != widget.javascript ||
+        !listEquals(oldWidget.allowedHosts, widget.allowedHosts);
+    if (!propsChanged) return;
+    _bindController(previousUrl: oldWidget.url);
+  }
+
+  @override
+  void dispose() {
+    _releaseCachedEntry();
+    super.dispose();
+  }
+
+  bool get _isStaticRendering {
+    return SlideConfiguration.of(context).isStaticRendering;
+  }
+
+  String _resolveCacheIdentity() {
+    final explicit = widget.cacheKey?.trim();
+    if (explicit != null && explicit.isNotEmpty) {
+      return 'key:$explicit';
+    }
+    return 'block:${BlockConfiguration.of(context).runtimeKey}';
+  }
+
+  Set<String> _effectiveAllowedHosts(String url) {
+    final explicit = widget.allowedHosts;
+    if (explicit != null && explicit.isNotEmpty) {
+      return explicit.toSet();
+    }
+    final host = Uri.tryParse(url)?.host;
+    if (host == null || host.isEmpty) return {};
+    return {host};
+  }
+
+  JavaScriptMode get _javaScriptMode =>
+      widget.javascript ? JavaScriptMode.unrestricted : JavaScriptMode.disabled;
+
+  void _bindController({String? previousUrl}) {
+    if (_isStaticRendering) {
+      _releaseCachedEntry();
+      _controller = null;
+      _localPolicy = null;
+      return;
+    }
+
+    final identity = _resolveCacheIdentity();
+    final cache = DeckController.of(context).webViewControllerCache;
+    final hosts = _effectiveAllowedHosts(widget.url);
+
+    _localPolicy = null;
+    _attachCached(cache, identity, hosts, previousUrl: previousUrl);
+  }
+
+  void _releaseCachedEntry({CachedWebViewEntry? entry}) {
+    final entryToRelease = entry ?? _cachedEntry;
+    entryToRelease?.release(_mountToken);
+    if (identical(_cachedEntry, entryToRelease)) {
+      _cachedEntry = null;
     }
   }
 
-  Future<void> _loadDartPad() async {
-    await _controller.loadRequest(Uri.parse(widget.url));
-  }
-
-  Future<void> _showDartPad() async {
-    await Future.delayed(const Duration(milliseconds: 500));
-    if (!mounted) return;
-    setState(() {
-      _hide = false;
+  void _attachCached(
+    WebViewControllerCache cache,
+    String identity,
+    Set<String> hosts, {
+    String? previousUrl,
+  }) {
+    final previousEntry = _cachedEntry;
+    final isNew = !cache.contains(identity);
+    final entry = cache.getOrCreate(identity, () {
+      return _createController(
+        onPageFinished: () => cache[identity]?.onPageFinished?.call(),
+        onNavigationRequest: (request) {
+          return cache[identity]?.policy.decide(request) ??
+              NavigationDecision.prevent;
+        },
+      );
     });
-  }
 
-  Future<void> _reloadDartPad() async {
-    setState(() {
+    final switchedEntry =
+        previousEntry != null && !identical(previousEntry, entry);
+    if (switchedEntry) {
+      _releaseCachedEntry(entry: previousEntry);
+    }
+
+    if (!entry.activate(_mountToken)) {
+      _cachedEntry = null;
+      _controller = null;
+      _localPolicy = null;
+      _attachLocal(hosts, previousUrl: previousUrl);
+      return;
+    }
+
+    entry.policy.allowedHosts = hosts;
+    entry.onPageFinished = _onPageFinished;
+    entry.controller.setJavaScriptMode(_javaScriptMode);
+
+    final alreadyLoaded = entry.loadedUrl == widget.url;
+    if (isNew || !alreadyLoaded) {
       _hide = true;
+      entry.loadedUrl = widget.url;
+      entry.controller.loadRequest(Uri.parse(widget.url));
+    } else if (switchedEntry || _controller == null) {
+      // Already warm — remount or entry switch will not fire page-finished.
+      _hide = false;
+    }
+
+    _cachedEntry = entry;
+    _controller = entry.controller;
+  }
+
+  void _attachLocal(Set<String> hosts, {String? previousUrl}) {
+    _cachedEntry = null;
+    final policy = _localPolicy ??= WebViewNavigationPolicy();
+    policy.allowedHosts = hosts;
+
+    if (_controller == null) {
+      _controller = _createController(
+        onPageFinished: _onPageFinished,
+        onNavigationRequest: policy.decide,
+      );
+      _hide = true;
+      _controller!.loadRequest(Uri.parse(widget.url));
+      return;
+    }
+
+    // Prop-only updates: always refresh JS mode; policy object is shared with
+    // the existing navigation delegate so host changes apply in place.
+    _controller!.setJavaScriptMode(_javaScriptMode);
+
+    if (previousUrl != widget.url) {
+      _hide = true;
+      _controller!.loadRequest(Uri.parse(widget.url));
+    }
+  }
+
+  WebViewController _createController({
+    required VoidCallback onPageFinished,
+    required FutureOr<NavigationDecision> Function(NavigationRequest)
+    onNavigationRequest,
+  }) {
+    return WebViewController()
+      ..setJavaScriptMode(_javaScriptMode)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (_) => onPageFinished(),
+          onNavigationRequest: onNavigationRequest,
+        ),
+      );
+  }
+
+  void _onPageFinished() {
+    Future<void>.delayed(const Duration(milliseconds: 500), () {
+      if (!mounted) return;
+      setState(() => _hide = false);
     });
-    await Future.delayed(const Duration(milliseconds: 150));
+  }
+
+  Future<void> _reload() async {
+    final controller = _controller;
+    if (controller == null) return;
+    setState(() => _hide = true);
+    await Future<void>.delayed(const Duration(milliseconds: 150));
     if (!mounted) return;
-    await _controller.reload();
+    await controller.reload();
   }
 
-  Future<void> executeInIframe(String code) {
-    return _controller.runJavaScript(code);
-  }
-
-  Future<void> clearDartPadEditor() {
-    return executeInIframe('''
+  Future<void> _clearDartPadEditor() {
+    final controller = _controller;
+    if (controller == null) return Future<void>.value();
+    return controller.runJavaScript('''
                 var editor = document.querySelector('.CodeMirror')?.CodeMirror;
                 if (editor) {
                   editor.setValue('');
@@ -101,24 +249,34 @@ class _WebViewWrapperState extends State<WebViewWrapper>
             ''');
   }
 
-  // Function to set content in the DartPad editor
-  Future<void> setDartPadEditorContent(String content) {
-    // Escape content as JSON string to prevent JavaScript injection
-    final escapedContent = jsonEncode(content);
-    return executeInIframe('''
-                var editor = document.querySelector('.CodeMirror')?.CodeMirror;
-                if(editor){
-                  editor.setValue($escapedContent);
-                  editor.setCursor(editor.lineCount(), 0);
-                  editor.focus();
-                  console.log('DartPad editor content set!');
-                }
-            ''');
+  Widget _buildPlaceholder() {
+    final title = widget.title?.trim();
+    final label = (title != null && title.isNotEmpty)
+        ? title
+        : 'WebView unavailable in static capture';
+    return SizedBox(
+      width: widget.size.width,
+      height: widget.size.height,
+      child: Center(
+        child: Text(
+          label,
+          textAlign: TextAlign.center,
+          style: const TextStyle(fontSize: 14),
+        ),
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
+    if (_isStaticRendering) return _buildPlaceholder();
+
+    final controller = _controller;
+    if (controller == null) {
+      return SizedBox(width: widget.size.width, height: widget.size.height);
+    }
+
+    final showToolbar = widget.showControls || widget.showClearControl;
 
     return SizedBox(
       width: widget.size.width,
@@ -128,15 +286,20 @@ class _WebViewWrapperState extends State<WebViewWrapper>
           AnimatedOpacity(
             opacity: _hide ? 0 : 1,
             duration: const Duration(milliseconds: 150),
-            child: WebViewWidget(controller: _controller),
+            child: WebViewWidget(controller: controller),
           ),
-          Row(
-            children: [
-              SDIconButton(onPressed: _reloadDartPad, icon: Icons.refresh),
-              // add button that clears the webview by running javascript
-              SDIconButton(onPressed: clearDartPadEditor, icon: Icons.clear),
-            ],
-          ),
+          if (showToolbar)
+            Row(
+              children: [
+                if (widget.showControls)
+                  SDIconButton(onPressed: _reload, icon: Icons.refresh),
+                if (widget.showClearControl)
+                  SDIconButton(
+                    onPressed: _clearDartPadEditor,
+                    icon: Icons.clear,
+                  ),
+              ],
+            ),
         ],
       ),
     );

--- a/packages/superdeck/test/src/builtins/dartpad_widget_test.dart
+++ b/packages/superdeck/test/src/builtins/dartpad_widget_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:superdeck/src/builtins/dartpad_widget.dart';
+import 'package:superdeck/src/deck/deck_controller.dart';
+import 'package:superdeck/src/deck/deck_options.dart';
+import 'package:superdeck/src/deck/slide_configuration.dart';
 import 'package:superdeck/src/rendering/blocks/block_provider.dart';
 import 'package:superdeck/src/styling/components/slide.dart';
 import 'package:superdeck/src/ui/widgets/provider.dart';
@@ -8,6 +11,8 @@ import 'package:superdeck/src/ui/widgets/webview_wrapper.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 // ignore: depend_on_referenced_packages
 import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
+
+import '../../helpers/mock_deck_loader.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -21,6 +26,7 @@ void main() {
         expect(dto.theme, isNull);
         expect(dto.embed, isTrue);
         expect(dto.run, isTrue);
+        expect(dto.cacheKey, isNull);
       });
     });
 
@@ -31,6 +37,7 @@ void main() {
           'theme': 'dark',
           'embed': false,
           'run': true,
+          'cacheKey': 'shared-pad',
         });
 
         expect(result.isOk, isTrue);
@@ -53,12 +60,14 @@ void main() {
           'theme': 'dark',
           'embed': false,
           'run': false,
+          'cacheKey': 'pad-1',
         });
 
         expect(dto.id, 'snippet');
         expect(dto.theme, DartPadTheme.dark);
         expect(dto.embed, isFalse);
         expect(dto.run, isFalse);
+        expect(dto.cacheKey, 'pad-1');
       });
 
       test('uses defaults when optional fields are omitted or null', () {
@@ -68,14 +77,17 @@ void main() {
           'theme': null,
           'embed': null,
           'run': null,
+          'cacheKey': null,
         });
 
         expect(omitted.theme, isNull);
         expect(omitted.embed, isTrue);
         expect(omitted.run, isTrue);
+        expect(omitted.cacheKey, isNull);
         expect(explicitNull.theme, isNull);
         expect(explicitNull.embed, isTrue);
         expect(explicitNull.run, isTrue);
+        expect(explicitNull.cacheKey, isNull);
       });
 
       test('rejects a missing or empty id', () {
@@ -126,10 +138,22 @@ void main() {
 
   group('DartPadWidget', () {
     late _FakeWebViewPlatform webViewPlatform;
+    late MockDeckLoader loader;
+    late DeckController deckController;
 
     setUp(() {
       webViewPlatform = _FakeWebViewPlatform();
       WebViewPlatform.instance = webViewPlatform;
+      loader = MockDeckLoader();
+      deckController = DeckController(
+        deckLoader: loader,
+        options: DeckOptions(),
+      );
+    });
+
+    tearDown(() async {
+      deckController.dispose();
+      await loader.dispose();
     });
 
     testWidgets('renders a web view wrapper for the DartPad URL', (
@@ -139,7 +163,9 @@ void main() {
 
       await tester.pumpWidget(
         _DartPadHarness(
+          deckController: deckController,
           size: size,
+          runtimeKey: 'slide-0:s0:b0',
           args: {
             'id': 'snippet',
             'theme': 'light',
@@ -162,6 +188,8 @@ void main() {
         wrapper.url,
         'https://dartpad.dev/?id=snippet&theme=light&embed=true&run=false',
       );
+      expect(wrapper.showControls, isTrue);
+      expect(wrapper.showClearControl, isTrue);
       expect(find.byKey(const ValueKey('fake-web-view')), findsOneWidget);
       expect(webViewPlatform.controllers, hasLength(1));
       expect(
@@ -179,7 +207,12 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        const _DartPadHarness(size: Size(640, 480), args: {'id': 'snippet'}),
+        _DartPadHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: const {'id': 'snippet'},
+        ),
       );
       await tester.pump();
 
@@ -197,7 +230,12 @@ void main() {
 
     testWidgets('page finished fades in the WebView', (tester) async {
       await tester.pumpWidget(
-        const _DartPadHarness(size: Size(640, 480), args: {'id': 'snippet'}),
+        _DartPadHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: const {'id': 'snippet'},
+        ),
       );
       await tester.pump();
 
@@ -221,14 +259,21 @@ void main() {
 
     testWidgets('loads a new request when DartPad URL updates', (tester) async {
       await tester.pumpWidget(
-        const _DartPadHarness(size: Size(640, 480), args: {'id': 'first'}),
+        _DartPadHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: const {'id': 'first'},
+        ),
       );
       await tester.pump();
 
       await tester.pumpWidget(
-        const _DartPadHarness(
-          size: Size(640, 480),
-          args: {'id': 'second', 'theme': 'dark'},
+        _DartPadHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: const {'id': 'second', 'theme': 'dark'},
         ),
       );
       await tester.pump();
@@ -241,11 +286,62 @@ void main() {
       );
     });
 
+    testWidgets(
+      'cached remount reuses controller and does not loadRequest again',
+      (tester) async {
+        await tester.pumpWidget(
+          _DartPadHarness(
+            deckController: deckController,
+            size: const Size(640, 480),
+            runtimeKey: 'slide-0:s0:b0',
+            args: const {'id': 'snippet'},
+          ),
+        );
+        await tester.pump();
+
+        expect(webViewPlatform.controllers, hasLength(1));
+        expect(webViewPlatform.controllers.single.loadedRequests, hasLength(1));
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+
+        await tester.pumpWidget(
+          _DartPadHarness(
+            deckController: deckController,
+            size: const Size(640, 480),
+            runtimeKey: 'slide-0:s0:b0',
+            args: const {'id': 'snippet'},
+          ),
+        );
+        await tester.pump();
+
+        expect(webViewPlatform.controllers, hasLength(1));
+        expect(webViewPlatform.controllers.single.loadedRequests, hasLength(1));
+
+        // Refresh and clear still work after remount.
+        await tester.tap(find.byIcon(Icons.refresh));
+        await tester.pump(const Duration(milliseconds: 200));
+        expect(webViewPlatform.controllers.single.reloadCount, 1);
+
+        await tester.tap(find.byIcon(Icons.clear));
+        await tester.pump();
+        expect(
+          webViewPlatform.controllers.single.javaScripts.single,
+          contains("setValue('')"),
+        );
+      },
+    );
+
     testWidgets('navigation delegate allows same host and blocks others', (
       tester,
     ) async {
       await tester.pumpWidget(
-        const _DartPadHarness(size: Size(640, 480), args: {'id': 'snippet'}),
+        _DartPadHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: const {'id': 'snippet'},
+        ),
       );
       await tester.pump();
 
@@ -276,21 +372,47 @@ void main() {
 }
 
 class _DartPadHarness extends StatelessWidget {
+  final DeckController deckController;
   final Map<String, Object?> args;
   final Size size;
+  final String runtimeKey;
 
-  const _DartPadHarness({required this.args, required this.size});
+  const _DartPadHarness({
+    required this.deckController,
+    required this.args,
+    required this.size,
+    required this.runtimeKey,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final slide = SlideConfiguration(
+      slideIndex: 0,
+      style: SlideStyle(),
+      slide: Slide(
+        key: 'slide-0',
+        sections: [
+          SectionBlock([ContentBlock('placeholder')]),
+        ],
+      ),
+      thumbnailKey: buildThumbnailKey('slide-0'),
+    );
+
     return MaterialApp(
-      home: InheritedData<BlockConfiguration>(
-        data: BlockConfiguration(
-          spec: const SlideSpec(),
-          size: size,
-          align: null,
+      home: InheritedData<DeckController>(
+        data: deckController,
+        child: InheritedData<SlideConfiguration>(
+          data: slide,
+          child: InheritedData<BlockConfiguration>(
+            data: BlockConfiguration(
+              spec: const SlideSpec(),
+              size: size,
+              align: null,
+              runtimeKey: runtimeKey,
+            ),
+            child: Scaffold(body: DartPadWidget(args)),
+          ),
         ),
-        child: Scaffold(body: DartPadWidget(args)),
       ),
     );
   }

--- a/packages/superdeck/test/src/builtins/image_widget_test.dart
+++ b/packages/superdeck/test/src/builtins/image_widget_test.dart
@@ -202,6 +202,7 @@ class _ImageHarness extends StatelessWidget {
           spec: const SlideSpec(),
           size: size,
           align: ContentAlignment.center,
+          runtimeKey: 'test-slide:s0:b0',
         ),
         child: Scaffold(body: ImageWidget(args)),
       ),

--- a/packages/superdeck/test/src/builtins/webview_widget_test.dart
+++ b/packages/superdeck/test/src/builtins/webview_widget_test.dart
@@ -1,0 +1,812 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:superdeck/src/builtins/webview_widget.dart';
+import 'package:superdeck/src/deck/deck_controller.dart';
+import 'package:superdeck/src/deck/deck_options.dart';
+import 'package:superdeck/src/deck/slide_configuration.dart';
+import 'package:superdeck/src/rendering/blocks/block_provider.dart';
+import 'package:superdeck/src/styling/components/slide.dart';
+import 'package:superdeck/src/ui/widgets/provider.dart';
+import 'package:superdeck/src/ui/widgets/webview_wrapper.dart';
+import 'package:superdeck_core/superdeck_core.dart';
+// ignore: depend_on_referenced_packages
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
+
+import '../../helpers/mock_deck_loader.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('WebViewDto', () {
+    group('schema', () {
+      test('accepts valid arguments', () {
+        final result = WebViewDto.schema.safeParse({
+          'url': 'https://example.com/page',
+          'cacheKey': 'shared',
+          'title': 'Example',
+          'allowedHosts': ['example.com', 'cdn.example.com'],
+          'showControls': true,
+          'javascript': false,
+        });
+
+        expect(result.isOk, isTrue);
+      });
+
+      test('rejects missing url', () {
+        final result = WebViewDto.schema.safeParse({});
+        expect(result.isOk, isFalse);
+      });
+    });
+
+    group('parse', () {
+      test('returns typed values with defaults', () {
+        final dto = WebViewDto.parse({'url': 'https://example.com'});
+
+        expect(dto.url, 'https://example.com');
+        expect(dto.cacheKey, isNull);
+        expect(dto.title, isNull);
+        expect(dto.allowedHosts, isNull);
+        expect(dto.showControls, isFalse);
+        expect(dto.javascript, isTrue);
+      });
+
+      test('parses optional fields', () {
+        final dto = WebViewDto.parse({
+          'url': 'https://example.com/app',
+          'cacheKey': 'k1',
+          'title': 'App',
+          'allowedHosts': ['example.com'],
+          'showControls': true,
+          'javascript': false,
+        });
+
+        expect(dto.cacheKey, 'k1');
+        expect(dto.title, 'App');
+        expect(dto.allowedHosts, ['example.com']);
+        expect(dto.showControls, isTrue);
+        expect(dto.javascript, isFalse);
+      });
+
+      test('rejects non-http schemes and relative urls', () {
+        final invalid = [
+          {'url': 'ftp://example.com'},
+          {'url': 'file:///tmp/x'},
+          {'url': 'javascript:alert(1)'},
+          {'url': '/relative/path'},
+          {'url': 'example.com'},
+          {'url': ''},
+        ];
+
+        for (final args in invalid) {
+          expect(
+            () => WebViewDto.parse(args),
+            throwsA(anything),
+            reason: 'should reject $args',
+          );
+        }
+      });
+
+      test('accepts http and https absolute urls', () {
+        expect(
+          WebViewDto.parse({'url': 'http://localhost:8080'}).url,
+          'http://localhost:8080',
+        );
+        expect(
+          WebViewDto.parse({'url': 'https://example.com/path?q=1'}).url,
+          'https://example.com/path?q=1',
+        );
+      });
+    });
+  });
+
+  group('WebViewWidget', () {
+    late _FakeWebViewPlatform webViewPlatform;
+    late MockDeckLoader loader;
+    late DeckController deckController;
+
+    setUp(() {
+      webViewPlatform = _FakeWebViewPlatform();
+      WebViewPlatform.instance = webViewPlatform;
+      loader = MockDeckLoader();
+      deckController = DeckController(
+        deckLoader: loader,
+        options: DeckOptions(),
+      );
+    });
+
+    tearDown(() async {
+      deckController.dispose();
+      await loader.dispose();
+    });
+
+    testWidgets('renders a web view for a valid url', (tester) async {
+      const size = Size(640, 480);
+
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: size,
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com/demo'},
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(WebViewWrapper), findsOneWidget);
+
+      final wrapper = tester.widget<WebViewWrapper>(
+        find.byType(WebViewWrapper),
+      );
+      expect(wrapper.size, size);
+      expect(wrapper.url, 'https://example.com/demo');
+      expect(wrapper.showControls, isFalse);
+      expect(find.byKey(const ValueKey('fake-web-view')), findsOneWidget);
+      expect(webViewPlatform.controllers, hasLength(1));
+      expect(
+        webViewPlatform.controllers.single.loadedRequests.single.uri.toString(),
+        'https://example.com/demo',
+      );
+      expect(
+        webViewPlatform.controllers.single.javaScriptMode,
+        JavaScriptMode.unrestricted,
+      );
+    });
+
+    testWidgets('reuses controller on remount with same cache identity', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com/a'},
+        ),
+      );
+      await tester.pump();
+
+      expect(webViewPlatform.controllers, hasLength(1));
+      expect(webViewPlatform.controllers.single.loadedRequests, hasLength(1));
+
+      // Dispose the tree (leave slide).
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      // Remount same block identity.
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com/a'},
+        ),
+      );
+      await tester.pump();
+
+      expect(webViewPlatform.controllers, hasLength(1));
+      expect(webViewPlatform.controllers.single.loadedRequests, hasLength(1));
+      expect(deckController.webViewControllerCache.length, 1);
+    });
+
+    testWidgets('loads again when url changes for the same identity', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com/first'},
+        ),
+      );
+      await tester.pump();
+
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com/second'},
+        ),
+      );
+      await tester.pump();
+
+      final controller = webViewPlatform.controllers.single;
+      expect(controller.loadedRequests, hasLength(2));
+      expect(
+        controller.loadedRequests.last.uri.toString(),
+        'https://example.com/second',
+      );
+    });
+
+    testWidgets(
+      'explicit cacheKey sequential remount reuses controller without reload',
+      (tester) async {
+        await tester.pumpWidget(
+          _WebViewHarness(
+            deckController: deckController,
+            size: const Size(640, 480),
+            runtimeKey: 'slide-0:s0:b0',
+            args: {
+              'url': 'https://example.com/shared',
+              'cacheKey': 'shared-key',
+            },
+          ),
+        );
+        await tester.pump();
+
+        expect(webViewPlatform.controllers, hasLength(1));
+        expect(webViewPlatform.controllers.single.loadedRequests, hasLength(1));
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+
+        // Different block runtime key, same cacheKey — sequential remount.
+        await tester.pumpWidget(
+          _WebViewHarness(
+            deckController: deckController,
+            size: const Size(640, 480),
+            runtimeKey: 'slide-1:s0:b0',
+            args: {
+              'url': 'https://example.com/shared',
+              'cacheKey': 'shared-key',
+            },
+          ),
+        );
+        await tester.pump();
+
+        expect(webViewPlatform.controllers, hasLength(1));
+        expect(webViewPlatform.controllers.single.loadedRequests, hasLength(1));
+        expect(
+          tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+          1,
+        );
+      },
+    );
+
+    testWidgets(
+      'concurrent same cacheKey mounts use a local fallback controller',
+      (tester) async {
+        await tester.pumpWidget(
+          _TwoWebViewsHarness(
+            deckController: deckController,
+            size: const Size(640, 240),
+            firstRuntimeKey: 'slide-0:s0:b0',
+            secondRuntimeKey: 'slide-0:s0:b1',
+            args: {
+              'url': 'https://example.com/shared',
+              'cacheKey': 'shared-key',
+            },
+          ),
+        );
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(WebViewWrapper), findsNWidgets(2));
+        expect(webViewPlatform.controllers, hasLength(2));
+        expect(deckController.webViewControllerCache.length, 1);
+        expect(
+          webViewPlatform.controllers[0].loadedRequests.single.uri.toString(),
+          'https://example.com/shared',
+        );
+        expect(
+          webViewPlatform.controllers[1].loadedRequests.single.uri.toString(),
+          'https://example.com/shared',
+        );
+      },
+    );
+
+    testWidgets(
+      'switching to an already-loaded cache identity reveals the surface',
+      (tester) async {
+        // Warm entry B.
+        await tester.pumpWidget(
+          _WebViewHarness(
+            deckController: deckController,
+            size: const Size(640, 480),
+            runtimeKey: 'slide-0:s0:b0',
+            args: {'url': 'https://example.com/b', 'cacheKey': 'entry-b'},
+          ),
+        );
+        await tester.pump();
+        final entryB = webViewPlatform.controllers.single;
+        expect(entryB.loadedRequests, hasLength(1));
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+
+        // Mount entry A (loading, surface hidden).
+        await tester.pumpWidget(
+          _WebViewHarness(
+            deckController: deckController,
+            size: const Size(640, 480),
+            runtimeKey: 'slide-0:s0:b0',
+            args: {'url': 'https://example.com/a', 'cacheKey': 'entry-a'},
+          ),
+        );
+        await tester.pump();
+        expect(webViewPlatform.controllers, hasLength(2));
+        expect(
+          tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+          0,
+        );
+
+        // Switch onto already-warmed B without remount (isInitial: false).
+        await tester.pumpWidget(
+          _WebViewHarness(
+            deckController: deckController,
+            size: const Size(640, 480),
+            runtimeKey: 'slide-0:s0:b0',
+            args: {'url': 'https://example.com/b', 'cacheKey': 'entry-b'},
+          ),
+        );
+        await tester.pump();
+
+        // B was already loaded — no additional loadRequest.
+        expect(entryB.loadedRequests, hasLength(1));
+        expect(
+          tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+          1,
+        );
+      },
+    );
+
+    testWidgets('rebinds when the inherited deck controller changes', (
+      tester,
+    ) async {
+      final secondLoader = MockDeckLoader();
+      final secondController = DeckController(
+        deckLoader: secondLoader,
+        options: DeckOptions(),
+      );
+      addTearDown(() async {
+        secondController.dispose();
+        await secondLoader.dispose();
+      });
+
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com'},
+        ),
+      );
+      await tester.pump();
+
+      expect(webViewPlatform.controllers, hasLength(1));
+      expect(deckController.webViewControllerCache.length, 1);
+
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: secondController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com'},
+        ),
+      );
+      await tester.pump();
+
+      expect(webViewPlatform.controllers, hasLength(2));
+      expect(secondController.webViewControllerCache.length, 1);
+      expect(
+        webViewPlatform.controllers.last.loadedRequests.single.uri.toString(),
+        'https://example.com',
+      );
+    });
+
+    testWidgets('javascript and allowedHosts updates without loadRequest', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {
+            'url': 'https://example.com',
+            'javascript': true,
+            'allowedHosts': ['example.com'],
+          },
+        ),
+      );
+      await tester.pump();
+
+      final controller = webViewPlatform.controllers.single;
+      expect(controller.loadedRequests, hasLength(1));
+      expect(controller.javaScriptMode, JavaScriptMode.unrestricted);
+
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {
+            'url': 'https://example.com',
+            'javascript': false,
+            'allowedHosts': ['example.com', 'cdn.example.com'],
+          },
+        ),
+      );
+      await tester.pump();
+
+      expect(controller.loadedRequests, hasLength(1));
+      expect(controller.javaScriptMode, JavaScriptMode.disabled);
+
+      final delegate =
+          controller.navigationDelegate! as _FakeNavigationDelegate;
+      expect(
+        await delegate.onNavigationRequest?.call(
+          const NavigationRequest(
+            url: 'https://cdn.example.com/asset.js',
+            isMainFrame: true,
+          ),
+        ),
+        NavigationDecision.navigate,
+      );
+    });
+
+    testWidgets('navigation policy allows configured hosts only', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {
+            'url': 'https://example.com',
+            'allowedHosts': ['example.com', 'cdn.example.com'],
+          },
+        ),
+      );
+      await tester.pump();
+
+      final delegate =
+          webViewPlatform.controllers.single.navigationDelegate!
+              as _FakeNavigationDelegate;
+
+      expect(
+        await delegate.onNavigationRequest?.call(
+          const NavigationRequest(
+            url: 'https://example.com/next',
+            isMainFrame: true,
+          ),
+        ),
+        NavigationDecision.navigate,
+      );
+      expect(
+        await delegate.onNavigationRequest?.call(
+          const NavigationRequest(
+            url: 'https://cdn.example.com/asset.js',
+            isMainFrame: true,
+          ),
+        ),
+        NavigationDecision.navigate,
+      );
+      expect(
+        await delegate.onNavigationRequest?.call(
+          const NavigationRequest(
+            url: 'https://evil.com/phishing',
+            isMainFrame: true,
+          ),
+        ),
+        NavigationDecision.prevent,
+      );
+    });
+
+    testWidgets('default host policy allows only source host', (tester) async {
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com/page'},
+        ),
+      );
+      await tester.pump();
+
+      final delegate =
+          webViewPlatform.controllers.single.navigationDelegate!
+              as _FakeNavigationDelegate;
+
+      expect(
+        await delegate.onNavigationRequest?.call(
+          const NavigationRequest(
+            url: 'https://example.com/other',
+            isMainFrame: true,
+          ),
+        ),
+        NavigationDecision.navigate,
+      );
+      expect(
+        await delegate.onNavigationRequest?.call(
+          const NavigationRequest(url: 'https://other.com/', isMainFrame: true),
+        ),
+        NavigationDecision.prevent,
+      );
+    });
+
+    testWidgets('showControls enables refresh', (tester) async {
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com', 'showControls': true},
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.refresh), findsOneWidget);
+      expect(find.byIcon(Icons.clear), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.refresh));
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(webViewPlatform.controllers.single.reloadCount, 1);
+    });
+
+    testWidgets('static rendering shows title placeholder without controller', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          isStaticRendering: true,
+          args: {'url': 'https://example.com', 'title': 'Static Title'},
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Static Title'), findsOneWidget);
+      expect(find.byKey(const ValueKey('fake-web-view')), findsNothing);
+      expect(webViewPlatform.controllers, isEmpty);
+      expect(deckController.webViewControllerCache.length, 0);
+    });
+
+    testWidgets('deck dispose clears the webview cache', (tester) async {
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com'},
+        ),
+      );
+      await tester.pump();
+
+      expect(deckController.webViewControllerCache.length, 1);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      deckController.dispose();
+
+      expect(deckController.webViewControllerCache.length, 0);
+
+      // Avoid double-dispose in tearDown by replacing with a fresh controller.
+      deckController = DeckController(
+        deckLoader: MockDeckLoader(),
+        options: DeckOptions(),
+      );
+    });
+
+    testWidgets('javascript false disables javascript mode', (tester) async {
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com', 'javascript': false},
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        webViewPlatform.controllers.single.javaScriptMode,
+        JavaScriptMode.disabled,
+      );
+    });
+  });
+}
+
+class _TwoWebViewsHarness extends StatelessWidget {
+  final DeckController deckController;
+  final Map<String, Object?> args;
+  final Size size;
+  final String firstRuntimeKey;
+  final String secondRuntimeKey;
+
+  const _TwoWebViewsHarness({
+    required this.deckController,
+    required this.args,
+    required this.size,
+    required this.firstRuntimeKey,
+    required this.secondRuntimeKey,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final slide = SlideConfiguration(
+      slideIndex: 0,
+      style: SlideStyle(),
+      slide: Slide(
+        key: 'slide-0',
+        sections: [
+          SectionBlock([ContentBlock('placeholder')]),
+        ],
+      ),
+      thumbnailKey: buildThumbnailKey('slide-0'),
+    );
+
+    Widget webView(String runtimeKey) {
+      return InheritedData<BlockConfiguration>(
+        data: BlockConfiguration(
+          spec: const SlideSpec(),
+          size: size,
+          align: null,
+          runtimeKey: runtimeKey,
+        ),
+        child: WebViewWidget(args),
+      );
+    }
+
+    return MaterialApp(
+      home: InheritedData<DeckController>(
+        data: deckController,
+        child: InheritedData<SlideConfiguration>(
+          data: slide,
+          child: Scaffold(
+            body: Column(
+              children: [webView(firstRuntimeKey), webView(secondRuntimeKey)],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WebViewHarness extends StatelessWidget {
+  final DeckController deckController;
+  final Map<String, Object?> args;
+  final Size size;
+  final String runtimeKey;
+  final bool isStaticRendering;
+
+  const _WebViewHarness({
+    required this.deckController,
+    required this.args,
+    required this.size,
+    required this.runtimeKey,
+    this.isStaticRendering = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final slide = SlideConfiguration(
+      slideIndex: 0,
+      style: SlideStyle(),
+      slide: Slide(
+        key: 'slide-0',
+        sections: [
+          SectionBlock([ContentBlock('placeholder')]),
+        ],
+      ),
+      thumbnailKey: buildThumbnailKey('slide-0'),
+      isStaticRendering: isStaticRendering,
+    );
+
+    return MaterialApp(
+      home: InheritedData<DeckController>(
+        data: deckController,
+        child: InheritedData<SlideConfiguration>(
+          data: slide,
+          child: InheritedData<BlockConfiguration>(
+            data: BlockConfiguration(
+              spec: const SlideSpec(),
+              size: size,
+              align: null,
+              runtimeKey: runtimeKey,
+            ),
+            child: Scaffold(body: WebViewWidget(args)),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FakeWebViewPlatform extends WebViewPlatform {
+  final controllers = <_FakeWebViewController>[];
+
+  @override
+  PlatformWebViewController createPlatformWebViewController(
+    PlatformWebViewControllerCreationParams params,
+  ) {
+    final controller = _FakeWebViewController(params);
+    controllers.add(controller);
+    return controller;
+  }
+
+  @override
+  PlatformNavigationDelegate createPlatformNavigationDelegate(
+    PlatformNavigationDelegateCreationParams params,
+  ) {
+    return _FakeNavigationDelegate(params);
+  }
+
+  @override
+  PlatformWebViewWidget createPlatformWebViewWidget(
+    PlatformWebViewWidgetCreationParams params,
+  ) {
+    return _FakeWebViewWidget(params);
+  }
+}
+
+class _FakeWebViewController extends PlatformWebViewController {
+  final loadedRequests = <LoadRequestParams>[];
+  final javaScripts = <String>[];
+
+  JavaScriptMode? javaScriptMode;
+  PlatformNavigationDelegate? navigationDelegate;
+  int reloadCount = 0;
+
+  _FakeWebViewController(super.params) : super.implementation();
+
+  @override
+  Future<void> loadRequest(LoadRequestParams params) async {
+    loadedRequests.add(params);
+  }
+
+  @override
+  Future<void> reload() async {
+    reloadCount += 1;
+  }
+
+  @override
+  Future<void> runJavaScript(String javaScript) async {
+    javaScripts.add(javaScript);
+  }
+
+  @override
+  Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) async {
+    this.javaScriptMode = javaScriptMode;
+  }
+
+  @override
+  Future<void> setPlatformNavigationDelegate(
+    PlatformNavigationDelegate handler,
+  ) async {
+    navigationDelegate = handler;
+  }
+}
+
+class _FakeNavigationDelegate extends PlatformNavigationDelegate {
+  NavigationRequestCallback? onNavigationRequest;
+  PageEventCallback? onPageFinished;
+
+  _FakeNavigationDelegate(super.params) : super.implementation();
+
+  @override
+  Future<void> setOnNavigationRequest(
+    NavigationRequestCallback onNavigationRequest,
+  ) async {
+    this.onNavigationRequest = onNavigationRequest;
+  }
+
+  @override
+  Future<void> setOnPageFinished(PageEventCallback onPageFinished) async {
+    this.onPageFinished = onPageFinished;
+  }
+}
+
+class _FakeWebViewWidget extends PlatformWebViewWidget {
+  _FakeWebViewWidget(super.params) : super.implementation();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(key: ValueKey('fake-web-view'));
+  }
+}

--- a/packages/superdeck/test/src/markdown/builders/text_element_builder_widget_test.dart
+++ b/packages/superdeck/test/src/markdown/builders/text_element_builder_widget_test.dart
@@ -205,6 +205,7 @@ class _MarkdownHarness extends StatelessWidget {
       align: ContentBlock(markdown).align,
       spec: slideSpec,
       size: const Size(800, 600),
+      runtimeKey: 'test-slide:s0:b0',
     );
 
     return MaterialApp(

--- a/packages/superdeck/test/src/markdown/image_cache_resolution_test.dart
+++ b/packages/superdeck/test/src/markdown/image_cache_resolution_test.dart
@@ -59,9 +59,7 @@ void main() {
     testWidgets('without a store, the original render path is unchanged', (
       tester,
     ) async {
-      await tester.pumpWidget(
-        const _MarkdownHarness(markdown: '![x]($_key)'),
-      );
+      await tester.pumpWidget(const _MarkdownHarness(markdown: '![x]($_key)'));
       await tester.pumpAndSettle();
 
       // No cache → no resolver widget; the bare ref is used directly.
@@ -122,6 +120,7 @@ class _MarkdownHarness extends StatelessWidget {
       align: ContentBlock(markdown).align,
       spec: slideSpec,
       size: const Size(800, 600),
+      runtimeKey: 'slide:s0:b0',
     );
 
     final tree = InheritedData<SlideConfiguration>(

--- a/packages/superdeck/test/src/markdown/image_element_rendering_test.dart
+++ b/packages/superdeck/test/src/markdown/image_element_rendering_test.dart
@@ -248,6 +248,7 @@ class _MarkdownHarness extends StatelessWidget {
       align: ContentBlock(markdown).align,
       spec: slideSpec,
       size: const Size(800, 600),
+      runtimeKey: 'slide:s0:b0',
     );
 
     return MaterialApp(

--- a/packages/superdeck/test/src/markdown/markdown_builders_test.dart
+++ b/packages/superdeck/test/src/markdown/markdown_builders_test.dart
@@ -246,6 +246,7 @@ class _MarkdownHarness extends StatelessWidget {
       align: ContentBlock(markdown).align,
       spec: slideSpec,
       size: const Size(800, 600),
+      runtimeKey: 'slide:s0:b0',
     );
 
     return MaterialApp(


### PR DESCRIPTION
Adds a built-in `@webview` backed by a deck-scoped `WebViewController` cache, and updates `@dartpad` to use the same wrapper so returning to slides does not reload embedded pages.
The cache is keyed by explicit `cacheKey` or the block runtime key, avoids concurrent native controller reuse with a local fallback, and skips live WebViews during static thumbnail rendering.
The rendering pipeline now provides required block runtime keys, and docs/tests cover WebView args, DartPad caching, navigation allowlists, static rendering, and cache cleanup.
Validation: `fvm dart analyze --fatal-infos`; `fvm flutter test test/src --exclude-tags ci-excluded`; `git diff --check`.
