### PR TITLE
Fix WebView support on Flutter web

### DIFF
--- a/packages/superdeck/lib/src/ui/widgets/webview_controller_cache.dart
+++ b/packages/superdeck/lib/src/ui/widgets/webview_controller_cache.dart
@@ -25,6 +25,9 @@ class CachedWebViewEntry {
   /// Active mount listens here for page-finished fade-in.
   void Function()? onPageFinished;
 
+  /// Whether the platform can report page-finished events for this controller.
+  bool pageFinishedCallbacksUnsupported = false;
+
   Object? _activeMount;
 
   CachedWebViewEntry({required this.controller});

--- a/packages/superdeck/lib/src/ui/widgets/webview_wrapper.dart
+++ b/packages/superdeck/lib/src/ui/widgets/webview_wrapper.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show FutureOr;
+import 'dart:async' show FutureOr, unawaited;
 
 import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart' show Icons;
@@ -54,6 +54,7 @@ class _WebViewWrapperState extends State<WebViewWrapper> {
   WebViewController? _controller;
   CachedWebViewEntry? _cachedEntry;
   WebViewNavigationPolicy? _localPolicy;
+  bool _pageFinishedCallbacksUnsupported = false;
   bool _hide = true;
 
   @override
@@ -140,12 +141,18 @@ class _WebViewWrapperState extends State<WebViewWrapper> {
     final entry = cache.getOrCreate(identity, () {
       return _createController(
         onPageFinished: () => cache[identity]?.onPageFinished?.call(),
+        onPageFinishedUnsupported: () {
+          cache[identity]?.pageFinishedCallbacksUnsupported = true;
+        },
         onNavigationRequest: (request) {
           return cache[identity]?.policy.decide(request) ??
               NavigationDecision.prevent;
         },
       );
     });
+    if (isNew && _pageFinishedCallbacksUnsupported) {
+      entry.pageFinishedCallbacksUnsupported = true;
+    }
 
     final switchedEntry =
         previousEntry != null && !identical(previousEntry, entry);
@@ -163,13 +170,14 @@ class _WebViewWrapperState extends State<WebViewWrapper> {
 
     entry.policy.allowedHosts = hosts;
     entry.onPageFinished = _onPageFinished;
-    entry.controller.setJavaScriptMode(_javaScriptMode);
+    _applyJavaScriptMode(entry.controller);
 
     final alreadyLoaded = entry.loadedUrl == widget.url;
     if (isNew || !alreadyLoaded) {
       _hide = true;
       entry.loadedUrl = widget.url;
       entry.controller.loadRequest(Uri.parse(widget.url));
+      _revealIfPageFinishedUnsupported(entry.pageFinishedCallbacksUnsupported);
     } else if (switchedEntry || _controller == null) {
       // Already warm — remount or entry switch will not fire page-finished.
       _hide = false;
@@ -187,36 +195,104 @@ class _WebViewWrapperState extends State<WebViewWrapper> {
     if (_controller == null) {
       _controller = _createController(
         onPageFinished: _onPageFinished,
+        onPageFinishedUnsupported: () {
+          _pageFinishedCallbacksUnsupported = true;
+        },
         onNavigationRequest: policy.decide,
       );
+      _applyJavaScriptMode(_controller!);
       _hide = true;
       _controller!.loadRequest(Uri.parse(widget.url));
+      _revealIfPageFinishedUnsupported(_pageFinishedCallbacksUnsupported);
       return;
     }
 
     // Prop-only updates: always refresh JS mode; policy object is shared with
     // the existing navigation delegate so host changes apply in place.
-    _controller!.setJavaScriptMode(_javaScriptMode);
+    _applyJavaScriptMode(_controller!);
 
     if (previousUrl != widget.url) {
       _hide = true;
       _controller!.loadRequest(Uri.parse(widget.url));
+      _revealIfPageFinishedUnsupported(_pageFinishedCallbacksUnsupported);
     }
   }
 
   WebViewController _createController({
     required VoidCallback onPageFinished,
+    required VoidCallback onPageFinishedUnsupported,
     required FutureOr<NavigationDecision> Function(NavigationRequest)
     onNavigationRequest,
   }) {
-    return WebViewController()
-      ..setJavaScriptMode(_javaScriptMode)
-      ..setNavigationDelegate(
-        NavigationDelegate(
-          onPageFinished: (_) => onPageFinished(),
-          onNavigationRequest: onNavigationRequest,
-        ),
-      );
+    final controller = WebViewController();
+    _pageFinishedCallbacksUnsupported = false;
+    _applyNavigationDelegate(
+      controller,
+      NavigationDelegate(
+        onPageFinished: (_) => onPageFinished(),
+        onNavigationRequest: onNavigationRequest,
+      ),
+      onUnsupported: onPageFinishedUnsupported,
+    );
+    return controller;
+  }
+
+  void _applyNavigationDelegate(
+    WebViewController controller,
+    NavigationDelegate delegate, {
+    required VoidCallback onUnsupported,
+  }) {
+    unawaited(
+      _setNavigationDelegateIfSupported(
+        controller,
+        delegate,
+        onUnsupported: onUnsupported,
+      ),
+    );
+  }
+
+  Future<void> _setNavigationDelegateIfSupported(
+    WebViewController controller,
+    NavigationDelegate delegate, {
+    required VoidCallback onUnsupported,
+  }) async {
+    try {
+      await controller.setNavigationDelegate(delegate);
+    } on UnimplementedError {
+      // webview_flutter_web does not expose iframe navigation callbacks.
+      _pageFinishedCallbacksUnsupported = true;
+      onUnsupported();
+      _revealWithoutPageFinished();
+    }
+  }
+
+  void _applyJavaScriptMode(WebViewController controller) {
+    unawaited(_setJavaScriptModeIfSupported(controller));
+  }
+
+  Future<void> _setJavaScriptModeIfSupported(
+    WebViewController controller,
+  ) async {
+    try {
+      await controller.setJavaScriptMode(_javaScriptMode);
+    } on UnimplementedError {
+      // webview_flutter_web does not implement JavaScript mode for iframes.
+    }
+  }
+
+  void _revealWithoutPageFinished() {
+    if (!_hide) return;
+    _hide = false;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {});
+    });
+  }
+
+  void _revealIfPageFinishedUnsupported(bool unsupported) {
+    if (unsupported) {
+      _revealWithoutPageFinished();
+    }
   }
 
   void _onPageFinished() {
@@ -232,13 +308,20 @@ class _WebViewWrapperState extends State<WebViewWrapper> {
     setState(() => _hide = true);
     await Future<void>.delayed(const Duration(milliseconds: 150));
     if (!mounted) return;
-    await controller.reload();
+    try {
+      await controller.reload();
+    } on UnimplementedError {
+      await controller.loadRequest(Uri.parse(widget.url));
+      if (!mounted) return;
+      setState(() => _hide = false);
+    }
   }
 
-  Future<void> _clearDartPadEditor() {
+  Future<void> _clearDartPadEditor() async {
     final controller = _controller;
-    if (controller == null) return Future<void>.value();
-    return controller.runJavaScript('''
+    if (controller == null) return;
+    try {
+      await controller.runJavaScript('''
                 var editor = document.querySelector('.CodeMirror')?.CodeMirror;
                 if (editor) {
                   editor.setValue('');
@@ -247,6 +330,9 @@ class _WebViewWrapperState extends State<WebViewWrapper> {
                   console.log('DartPad editor cleared!');
                 }
             ''');
+    } on UnimplementedError {
+      // webview_flutter_web does not allow JavaScript injection into iframes.
+    }
   }
 
   Widget _buildPlaceholder() {

--- a/packages/superdeck/test/src/builtins/dartpad_widget_test.dart
+++ b/packages/superdeck/test/src/builtins/dartpad_widget_test.dart
@@ -228,6 +228,35 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('controls tolerate unsupported web iframe APIs', (
+      tester,
+    ) async {
+      webViewPlatform = _WebLikeWebViewPlatform();
+      WebViewPlatform.instance = webViewPlatform;
+
+      await tester.pumpWidget(
+        _DartPadHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: const {'id': 'snippet'},
+        ),
+      );
+      await tester.pump();
+
+      final controller = webViewPlatform.controllers.single;
+
+      await tester.tap(find.byIcon(Icons.refresh));
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.reloadCount, 0);
+      expect(controller.loadedRequests, hasLength(2));
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pump();
+      expect(controller.javaScripts, isEmpty);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('page finished fades in the WebView', (tester) async {
       await tester.pumpWidget(
         _DartPadHarness(
@@ -445,6 +474,17 @@ class _FakeWebViewPlatform extends WebViewPlatform {
   }
 }
 
+class _WebLikeWebViewPlatform extends _FakeWebViewPlatform {
+  @override
+  PlatformWebViewController createPlatformWebViewController(
+    PlatformWebViewControllerCreationParams params,
+  ) {
+    final controller = _WebLikeWebViewController(params);
+    controllers.add(controller);
+    return controller;
+  }
+}
+
 class _FakeWebViewController extends PlatformWebViewController {
   final loadedRequests = <LoadRequestParams>[];
   final javaScripts = <String>[];
@@ -480,6 +520,40 @@ class _FakeWebViewController extends PlatformWebViewController {
     PlatformNavigationDelegate handler,
   ) async {
     navigationDelegate = handler;
+  }
+}
+
+class _WebLikeWebViewController extends _FakeWebViewController {
+  _WebLikeWebViewController(super.params);
+
+  @override
+  Future<void> reload() {
+    throw UnimplementedError(
+      'reload is not implemented on the current platform',
+    );
+  }
+
+  @override
+  Future<void> runJavaScript(String javaScript) {
+    throw UnimplementedError(
+      'runJavaScript is not implemented on the current platform',
+    );
+  }
+
+  @override
+  Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) {
+    throw UnimplementedError(
+      'setJavaScriptMode is not implemented on the current platform',
+    );
+  }
+
+  @override
+  Future<void> setPlatformNavigationDelegate(
+    PlatformNavigationDelegate handler,
+  ) {
+    throw UnimplementedError(
+      'setPlatformNavigationDelegate is not implemented on the current platform',
+    );
   }
 }
 

--- a/packages/superdeck/test/src/builtins/webview_widget_test.dart
+++ b/packages/superdeck/test/src/builtins/webview_widget_test.dart
@@ -153,6 +153,39 @@ void main() {
       );
     });
 
+    testWidgets('renders when optional webview APIs are unsupported', (
+      tester,
+    ) async {
+      webViewPlatform = _WebLikeWebViewPlatform();
+      WebViewPlatform.instance = webViewPlatform;
+
+      await tester.pumpWidget(
+        _WebViewHarness(
+          deckController: deckController,
+          size: const Size(640, 480),
+          runtimeKey: 'slide-0:s0:b0',
+          args: {'url': 'https://example.com/web', 'javascript': false},
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
+
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(const ValueKey('fake-web-view')), findsOneWidget);
+      expect(webViewPlatform.controllers, hasLength(1));
+      expect(webViewPlatform.controllers.single.navigationDelegate, isNull);
+      expect(webViewPlatform.controllers.single.javaScriptMode, isNull);
+      expect(
+        tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+        1,
+      );
+      expect(
+        webViewPlatform.controllers.single.loadedRequests.single.uri.toString(),
+        'https://example.com/web',
+      );
+    });
+
     testWidgets('reuses controller on remount with same cache identity', (
       tester,
     ) async {
@@ -547,6 +580,42 @@ void main() {
       expect(webViewPlatform.controllers.single.reloadCount, 1);
     });
 
+    testWidgets(
+      'refresh falls back to loadRequest when reload is unsupported',
+      (tester) async {
+        webViewPlatform = _WebLikeWebViewPlatform();
+        WebViewPlatform.instance = webViewPlatform;
+
+        await tester.pumpWidget(
+          _WebViewHarness(
+            deckController: deckController,
+            size: const Size(640, 480),
+            runtimeKey: 'slide-0:s0:b0',
+            args: {'url': 'https://example.com', 'showControls': true},
+          ),
+        );
+        await tester.pump();
+
+        final controller = webViewPlatform.controllers.single;
+
+        await tester.tap(find.byIcon(Icons.refresh));
+        await tester.pump(const Duration(milliseconds: 200));
+        await tester.pump(const Duration(milliseconds: 150));
+
+        expect(tester.takeException(), isNull);
+        expect(controller.reloadCount, 0);
+        expect(controller.loadedRequests, hasLength(2));
+        expect(
+          controller.loadedRequests.last.uri.toString(),
+          'https://example.com',
+        );
+        expect(
+          tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+          1,
+        );
+      },
+    );
+
     testWidgets('static rendering shows title placeholder without controller', (
       tester,
     ) async {
@@ -745,6 +814,17 @@ class _FakeWebViewPlatform extends WebViewPlatform {
   }
 }
 
+class _WebLikeWebViewPlatform extends _FakeWebViewPlatform {
+  @override
+  PlatformWebViewController createPlatformWebViewController(
+    PlatformWebViewControllerCreationParams params,
+  ) {
+    final controller = _WebLikeWebViewController(params);
+    controllers.add(controller);
+    return controller;
+  }
+}
+
 class _FakeWebViewController extends PlatformWebViewController {
   final loadedRequests = <LoadRequestParams>[];
   final javaScripts = <String>[];
@@ -780,6 +860,40 @@ class _FakeWebViewController extends PlatformWebViewController {
     PlatformNavigationDelegate handler,
   ) async {
     navigationDelegate = handler;
+  }
+}
+
+class _WebLikeWebViewController extends _FakeWebViewController {
+  _WebLikeWebViewController(super.params);
+
+  @override
+  Future<void> reload() {
+    throw UnimplementedError(
+      'reload is not implemented on the current platform',
+    );
+  }
+
+  @override
+  Future<void> runJavaScript(String javaScript) {
+    throw UnimplementedError(
+      'runJavaScript is not implemented on the current platform',
+    );
+  }
+
+  @override
+  Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) {
+    throw UnimplementedError(
+      'setJavaScriptMode is not implemented on the current platform',
+    );
+  }
+
+  @override
+  Future<void> setPlatformNavigationDelegate(
+    PlatformNavigationDelegate handler,
+  ) {
+    throw UnimplementedError(
+      'setPlatformNavigationDelegate is not implemented on the current platform',
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- Handle unsupported `webview_flutter_web` controller APIs used by SuperDeck's shared WebView wrapper.
- Keep JavaScript mode and navigation delegates as best-effort capabilities so unsupported web iframe implementations do not crash rendering.
- Fall back from `reload()` to `loadRequest()` on web and treat DartPad clear as a no-op when JavaScript injection is unavailable.
- Add regression coverage for WebView and DartPad paths using a web-like controller that throws the same unsupported API errors.

## Root Cause

`webview_flutter_web` only implements iframe loading APIs such as `loadRequest` and `loadHtmlString`. Calls such as `setJavaScriptMode`, `setNavigationDelegate`, `reload`, and `runJavaScript` fall back to the platform interface default and throw `UnimplementedError` on web.

## Notes

`allowedHosts` navigation blocking still cannot be enforced through the `webview_flutter_web` controller path because the plugin does not expose navigation callbacks. Native platforms continue to use the navigation delegate path.

## Validation

- `fvm dart format lib/src/ui/widgets/webview_wrapper.dart lib/src/ui/widgets/webview_controller_cache.dart test/src/builtins/webview_widget_test.dart test/src/builtins/dartpad_widget_test.dart --set-exit-if-changed`
- `fvm flutter test test/src/builtins/webview_widget_test.dart`
- `fvm flutter test test/src/builtins/dartpad_widget_test.dart`
- `fvm dart analyze --fatal-infos`
- `git diff --check`
- `dcm analyze . --fatal-style --fatal-warnings`
- `fvm flutter build web --debug`
