### PR TITLE
Fix webview navigation delegate fallback

### DIFF
--- a/packages/superdeck/lib/src/ui/widgets/webview_wrapper.dart
+++ b/packages/superdeck/lib/src/ui/widgets/webview_wrapper.dart
@@ -226,37 +226,34 @@ class _WebViewWrapperState extends State<WebViewWrapper> {
   }) {
     final controller = WebViewController();
     _pageFinishedCallbacksUnsupported = false;
-    _applyNavigationDelegate(
-      controller,
-      NavigationDelegate(
-        onPageFinished: (_) => onPageFinished(),
+    unawaited(
+      _setNavigationDelegateIfSupported(
+        controller,
+        onPageFinished: onPageFinished,
         onNavigationRequest: onNavigationRequest,
+        onUnsupported: onPageFinishedUnsupported,
       ),
-      onUnsupported: onPageFinishedUnsupported,
     );
     return controller;
   }
 
-  void _applyNavigationDelegate(
-    WebViewController controller,
-    NavigationDelegate delegate, {
-    required VoidCallback onUnsupported,
-  }) {
-    unawaited(
-      _setNavigationDelegateIfSupported(
-        controller,
-        delegate,
-        onUnsupported: onUnsupported,
-      ),
-    );
-  }
-
   Future<void> _setNavigationDelegateIfSupported(
-    WebViewController controller,
-    NavigationDelegate delegate, {
+    WebViewController controller, {
+    required VoidCallback onPageFinished,
+    required FutureOr<NavigationDecision> Function(NavigationRequest)
+    onNavigationRequest,
     required VoidCallback onUnsupported,
   }) async {
     try {
+      // On webview_flutter_web the NavigationDelegate constructor itself throws
+      // (createPlatformNavigationDelegate is unimplemented), so it must be built
+      // inside this guard — not passed in pre-constructed — or the throw escapes
+      // before the try runs. setNavigationDelegate throws on web too; the same
+      // fallback covers both.
+      final delegate = NavigationDelegate(
+        onPageFinished: (_) => onPageFinished(),
+        onNavigationRequest: onNavigationRequest,
+      );
       await controller.setNavigationDelegate(delegate);
     } on UnimplementedError {
       // webview_flutter_web does not expose iframe navigation callbacks.

--- a/packages/superdeck/test/src/builtins/dartpad_widget_test.dart
+++ b/packages/superdeck/test/src/builtins/dartpad_widget_test.dart
@@ -483,6 +483,18 @@ class _WebLikeWebViewPlatform extends _FakeWebViewPlatform {
     controllers.add(controller);
     return controller;
   }
+
+  @override
+  PlatformNavigationDelegate createPlatformNavigationDelegate(
+    PlatformNavigationDelegateCreationParams params,
+  ) {
+    // Mirrors webview_flutter_web, which does not implement
+    // createPlatformNavigationDelegate. NavigationDelegate(...) therefore throws
+    // at construction, before the controller's setNavigationDelegate is reached.
+    throw UnimplementedError(
+      'createPlatformNavigationDelegate is not implemented on the current platform.',
+    );
+  }
 }
 
 class _FakeWebViewController extends PlatformWebViewController {

--- a/packages/superdeck/test/src/builtins/webview_widget_test.dart
+++ b/packages/superdeck/test/src/builtins/webview_widget_test.dart
@@ -823,6 +823,18 @@ class _WebLikeWebViewPlatform extends _FakeWebViewPlatform {
     controllers.add(controller);
     return controller;
   }
+
+  @override
+  PlatformNavigationDelegate createPlatformNavigationDelegate(
+    PlatformNavigationDelegateCreationParams params,
+  ) {
+    // Mirrors webview_flutter_web, which does not implement
+    // createPlatformNavigationDelegate. NavigationDelegate(...) therefore throws
+    // at construction, before the controller's setNavigationDelegate is reached.
+    throw UnimplementedError(
+      'createPlatformNavigationDelegate is not implemented on the current platform.',
+    );
+  }
 }
 
 class _FakeWebViewController extends PlatformWebViewController {


### PR DESCRIPTION
## Summary
Handles web platforms where `NavigationDelegate` construction throws because `createPlatformNavigationDelegate` is unimplemented, so `WebViewWrapper` falls back to revealing iframe-backed webviews without page-finished callbacks.
Adds web-like fake platform coverage for both `@webview` and `@dartpad` tests to model the constructor failure path.

## Validation
- `fvm flutter test test/src/builtins/webview_widget_test.dart test/src/builtins/dartpad_widget_test.dart`