### PR TITLE
Add fullscreen slide layout

### DIFF
--- a/demo/.superdeck/build_status.json
+++ b/demo/.superdeck/build_status.json
@@ -1,6 +1,6 @@
 {
   "status": "success",
-  "timestamp": "2026-06-16T18:16:23.856897Z",
-  "slideCount": 28,
+  "timestamp": "2026-07-09T16:49:37.909205Z",
+  "slideCount": 30,
   "error": null
 }

--- a/demo/.superdeck/superdeck.json
+++ b/demo/.superdeck/superdeck.json
@@ -763,6 +763,55 @@
     "comments": []
   },
   {
+    "key": "zH0cr0qi",
+    "options": {
+      "title": "WebView Normal"
+    },
+    "sections": [
+      {
+        "blocks": [
+          {
+            "name": "webview",
+            "flex": 1,
+            "scrollable": false,
+            "type": "widget",
+            "url": "https://www.fluttermix.com",
+            "title": "Flutter Mix",
+            "cacheKey": "fluttermix-normal"
+          }
+        ],
+        "flex": 1,
+        "type": "section"
+      }
+    ],
+    "comments": []
+  },
+  {
+    "key": "rJAYnWki",
+    "options": {
+      "title": "WebView Fullscreen",
+      "layout": "fullscreen"
+    },
+    "sections": [
+      {
+        "blocks": [
+          {
+            "name": "webview",
+            "flex": 1,
+            "scrollable": false,
+            "type": "widget",
+            "url": "https://www.fluttermix.com",
+            "title": "Flutter Mix",
+            "cacheKey": "fluttermix-fullscreen"
+          }
+        ],
+        "flex": 1,
+        "type": "section"
+      }
+    ],
+    "comments": []
+  },
+  {
     "key": "MKokn2KA",
     "options": {},
     "sections": [

--- a/demo/.superdeck/superdeck_full.json
+++ b/demo/.superdeck/superdeck_full.json
@@ -2277,6 +2277,55 @@
     "comments": []
   },
   {
+    "key": "zH0cr0qi",
+    "options": {
+      "title": "WebView Normal"
+    },
+    "sections": [
+      {
+        "blocks": [
+          {
+            "name": "webview",
+            "flex": 1,
+            "scrollable": false,
+            "type": "widget",
+            "url": "https://www.fluttermix.com",
+            "title": "Flutter Mix",
+            "cacheKey": "fluttermix-normal"
+          }
+        ],
+        "flex": 1,
+        "type": "section"
+      }
+    ],
+    "comments": []
+  },
+  {
+    "key": "rJAYnWki",
+    "options": {
+      "title": "WebView Fullscreen",
+      "layout": "fullscreen"
+    },
+    "sections": [
+      {
+        "blocks": [
+          {
+            "name": "webview",
+            "flex": 1,
+            "scrollable": false,
+            "type": "widget",
+            "url": "https://www.fluttermix.com",
+            "title": "Flutter Mix",
+            "cacheKey": "fluttermix-fullscreen"
+          }
+        ],
+        "flex": 1,
+        "type": "section"
+      }
+    ],
+    "comments": []
+  },
+  {
     "key": "MKokn2KA",
     "options": {},
     "sections": [

--- a/demo/slides.md
+++ b/demo/slides.md
@@ -407,6 +407,27 @@ template: minimal
 A clean, typography-focused template with no chrome distractions.
 
 ---
+title: WebView Normal
+---
+
+@webview {
+  url: "https://www.fluttermix.com"
+  title: "Flutter Mix"
+  cacheKey: "fluttermix-normal"
+}
+
+---
+title: WebView Fullscreen
+layout: fullscreen
+---
+
+@webview {
+  url: "https://www.fluttermix.com"
+  title: "Flutter Mix"
+  cacheKey: "fluttermix-fullscreen"
+}
+
+---
 
 @section{
   align: bottomCenter

--- a/demo/web/flutter_bootstrap.js
+++ b/demo/web/flutter_bootstrap.js
@@ -2,47 +2,45 @@
 {{flutter_js}}
 {{flutter_build_config}}
 
-;(() => {
-  const loader = document.getElementById('flutter-loader');
-  const loaderCopy = document.getElementById('flutter-loader-copy');
-  const loaderErrorTimeout = window.setTimeout(() => {
-    if (!loader || !loaderCopy || loader.classList.contains('is-hidden')) {
-      return;
-    }
-
-    loaderCopy.classList.add('is-error');
-    loaderCopy.textContent =
-      'Startup is taking longer than expected. Refresh the page or check the browser console.';
-  }, 15000);
-
-  function updateLoaderCopy(text) {
-    if (!loaderCopy) {
-      return;
-    }
-
-    loaderCopy.classList.remove('is-error');
-    loaderCopy.textContent = text;
+const loader = document.getElementById('flutter-loader');
+const loaderCopy = document.getElementById('flutter-loader-copy');
+const loaderErrorTimeout = window.setTimeout(() => {
+  if (!loader || !loaderCopy || loader.classList.contains('is-hidden')) {
+    return;
   }
 
-  function hideLoader() {
-    if (!loader) {
-      return;
-    }
+  loaderCopy.classList.add('is-error');
+  loaderCopy.textContent =
+    'Startup is taking longer than expected. Refresh the page or check the browser console.';
+}, 15000);
 
-    window.clearTimeout(loaderErrorTimeout);
-    loader.classList.add('is-hidden');
-    window.setTimeout(() => loader.remove(), 220);
+function updateLoaderCopy(text) {
+  if (!loaderCopy) {
+    return;
   }
 
-  _flutter.loader.load({
-    onEntrypointLoaded: async function (engineInitializer) {
-      updateLoaderCopy('Initializing engine…');
-      const appRunner = await engineInitializer.initializeEngine();
+  loaderCopy.classList.remove('is-error');
+  loaderCopy.textContent = text;
+}
 
-      updateLoaderCopy('Starting app…');
-      await appRunner.runApp();
+function hideLoader() {
+  if (!loader) {
+    return;
+  }
 
-      hideLoader();
-    },
-  });
-})();
+  window.clearTimeout(loaderErrorTimeout);
+  loader.classList.add('is-hidden');
+  window.setTimeout(() => loader.remove(), 220);
+}
+
+_flutter.loader.load({
+  onEntrypointLoaded: async function (engineInitializer) {
+    updateLoaderCopy('Initializing engine…');
+    const appRunner = await engineInitializer.initializeEngine();
+
+    updateLoaderCopy('Starting app…');
+    await appRunner.runApp();
+
+    hideLoader();
+  },
+});

--- a/demo/web/flutter_bootstrap.js
+++ b/demo/web/flutter_bootstrap.js
@@ -2,45 +2,47 @@
 {{flutter_js}}
 {{flutter_build_config}}
 
-const loader = document.getElementById('flutter-loader');
-const loaderCopy = document.getElementById('flutter-loader-copy');
-const loaderErrorTimeout = window.setTimeout(() => {
-  if (!loader || !loaderCopy || loader.classList.contains('is-hidden')) {
-    return;
+;(() => {
+  const loader = document.getElementById('flutter-loader');
+  const loaderCopy = document.getElementById('flutter-loader-copy');
+  const loaderErrorTimeout = window.setTimeout(() => {
+    if (!loader || !loaderCopy || loader.classList.contains('is-hidden')) {
+      return;
+    }
+
+    loaderCopy.classList.add('is-error');
+    loaderCopy.textContent =
+      'Startup is taking longer than expected. Refresh the page or check the browser console.';
+  }, 15000);
+
+  function updateLoaderCopy(text) {
+    if (!loaderCopy) {
+      return;
+    }
+
+    loaderCopy.classList.remove('is-error');
+    loaderCopy.textContent = text;
   }
 
-  loaderCopy.classList.add('is-error');
-  loaderCopy.textContent =
-    'Startup is taking longer than expected. Refresh the page or check the browser console.';
-}, 15000);
+  function hideLoader() {
+    if (!loader) {
+      return;
+    }
 
-function updateLoaderCopy(text) {
-  if (!loaderCopy) {
-    return;
+    window.clearTimeout(loaderErrorTimeout);
+    loader.classList.add('is-hidden');
+    window.setTimeout(() => loader.remove(), 220);
   }
 
-  loaderCopy.classList.remove('is-error');
-  loaderCopy.textContent = text;
-}
+  _flutter.loader.load({
+    onEntrypointLoaded: async function (engineInitializer) {
+      updateLoaderCopy('Initializing engine…');
+      const appRunner = await engineInitializer.initializeEngine();
 
-function hideLoader() {
-  if (!loader) {
-    return;
-  }
+      updateLoaderCopy('Starting app…');
+      await appRunner.runApp();
 
-  window.clearTimeout(loaderErrorTimeout);
-  loader.classList.add('is-hidden');
-  window.setTimeout(() => loader.remove(), 220);
-}
-
-_flutter.loader.load({
-  onEntrypointLoaded: async function (engineInitializer) {
-    updateLoaderCopy('Initializing engine…');
-    const appRunner = await engineInitializer.initializeEngine();
-
-    updateLoaderCopy('Starting app…');
-    await appRunner.runApp();
-
-    hideLoader();
-  },
-});
+      hideLoader();
+    },
+  });
+})();

--- a/docs/guides/markdown-authoring.mdx
+++ b/docs/guides/markdown-authoring.mdx
@@ -47,7 +47,7 @@ layout: fullscreen
 ---
 ````
 
-Use `layout: fullscreen` for full-bleed slides. It removes header and footer chrome, keeps the resolved background, and zeroes default block padding and margin. Named styles still apply after the layout defaults, so a slide can opt back into spacing with `style`.
+Use `layout: fullscreen` for chrome-free fullscreen slides. It removes header and footer chrome while keeping the resolved background and style.
 
 ---
 

--- a/docs/guides/markdown-authoring.mdx
+++ b/docs/guides/markdown-authoring.mdx
@@ -35,15 +35,19 @@ Each slide can have YAML front matter with these options:
 
 - `title` – Slide title (appears in navigation and exports)
 - `style` – Named style variant to apply (defined in `DeckOptions.styles`)
+- `layout` – Slide layout mode: `normal` or `fullscreen`
 - `template` – Named template to apply (defined in `DeckOptions.templates`; `'none'` to opt out)
-- Custom keys – Access via `slide.options.args['keyName']` in slide parts
+- Custom keys – Access via `slide.options.args['keyName']` in slide parts. Official keys such as `layout` are not included in `args`
 
 ````markdown
 ---
 title: Product Vision
 style: overview
+layout: fullscreen
 ---
 ````
+
+Use `layout: fullscreen` for full-bleed slides. It removes header and footer chrome, keeps the resolved background, and removes default block padding. Named styles still apply afterward, so a slide can opt back into spacing with `style`.
 
 ---
 

--- a/docs/guides/markdown-authoring.mdx
+++ b/docs/guides/markdown-authoring.mdx
@@ -47,7 +47,7 @@ layout: fullscreen
 ---
 ````
 
-Use `layout: fullscreen` for full-bleed slides. It removes header and footer chrome, keeps the resolved background, and removes default block padding. Named styles still apply afterward, so a slide can opt back into spacing with `style`.
+Use `layout: fullscreen` for full-bleed slides. It removes header and footer chrome, keeps the resolved background, and zeroes default block padding and margin. Named styles still apply after the layout defaults, so a slide can opt back into spacing with `style`.
 
 ---
 

--- a/docs/guides/slide-parts.mdx
+++ b/docs/guides/slide-parts.mdx
@@ -115,5 +115,5 @@ Common fields:
 
 - Keep parts lightweight; they rebuild on every slide.
 - Handle missing frontmatter (`title`, `style`, and `layout` can be null).
-- Use `layout: fullscreen` when a slide should suppress resolved header/footer chrome while keeping its background (default block padding and margin are also zeroed; named styles still apply afterward).
+- Use `layout: fullscreen` when a slide should suppress resolved header/footer chrome while keeping its background and style.
 - Use `DeckOptions(debug: true)` while designing layouts.

--- a/docs/guides/slide-parts.mdx
+++ b/docs/guides/slide-parts.mdx
@@ -107,11 +107,13 @@ Common fields:
 - `slide.slideIndex`
 - `slide.options.title`
 - `slide.options.style`
+- `slide.options.layout`
 - `slide.options.args` (frontmatter extras)
 - `slide.comments` (speaker notes)
 
 ## Tips
 
 - Keep parts lightweight; they rebuild on every slide.
-- Handle missing frontmatter (`title` and `style` can be null).
+- Handle missing frontmatter (`title`, `style`, and `layout` can be null).
+- Use `layout: fullscreen` when a slide should suppress resolved header/footer chrome while keeping its background.
 - Use `DeckOptions(debug: true)` while designing layouts.

--- a/docs/guides/slide-parts.mdx
+++ b/docs/guides/slide-parts.mdx
@@ -115,5 +115,5 @@ Common fields:
 
 - Keep parts lightweight; they rebuild on every slide.
 - Handle missing frontmatter (`title`, `style`, and `layout` can be null).
-- Use `layout: fullscreen` when a slide should suppress resolved header/footer chrome while keeping its background.
+- Use `layout: fullscreen` when a slide should suppress resolved header/footer chrome while keeping its background (default block padding and margin are also zeroed; named styles still apply afterward).
 - Use `DeckOptions(debug: true)` while designing layouts.

--- a/docs/reference/contracts.mdx
+++ b/docs/reference/contracts.mdx
@@ -61,7 +61,7 @@ Each slide object contains these fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `layout` | `"normal" \| "fullscreen"?` | Slide layout mode. `fullscreen` removes resolved header/footer chrome and uses full-bleed default block spacing |
+| `layout` | `"normal" \| "fullscreen"?` | Slide layout mode. `fullscreen` removes resolved header/footer chrome, keeps the resolved background, and zeroes default block padding and margin (named `style` merges after layout) |
 | `style` | `string?` | Named style variant to apply |
 | `template` | `string?` | Named template to apply (`"none"` to opt out) |
 | `title` | `string?` | Slide title for navigation and export |

--- a/docs/reference/contracts.mdx
+++ b/docs/reference/contracts.mdx
@@ -61,7 +61,7 @@ Each slide object contains these fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `layout` | `"normal" \| "fullscreen"?` | Slide layout mode. `fullscreen` removes resolved header/footer chrome, keeps the resolved background, and zeroes default block padding and margin (named `style` merges after layout) |
+| `layout` | `"normal" \| "fullscreen"?` | Slide layout mode. `fullscreen` removes resolved header/footer chrome while keeping the resolved background and style |
 | `style` | `string?` | Named style variant to apply |
 | `template` | `string?` | Named template to apply (`"none"` to opt out) |
 | `title` | `string?` | Slide title for navigation and export |

--- a/docs/reference/contracts.mdx
+++ b/docs/reference/contracts.mdx
@@ -18,6 +18,7 @@ The compiled payload is a raw JSON array of slide objects — no root wrapper, n
     "options": {
       "title": "Welcome",
       "style": "title",
+      "layout": "fullscreen",
       "template": "brand"
     },
     "sections": [
@@ -60,6 +61,7 @@ Each slide object contains these fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `layout` | `"normal" \| "fullscreen"?` | Slide layout mode. `fullscreen` removes resolved header/footer chrome and uses full-bleed default block spacing |
 | `style` | `string?` | Named style variant to apply |
 | `template` | `string?` | Named template to apply (`"none"` to opt out) |
 | `title` | `string?` | Slide title for navigation and export |

--- a/docs/reference/deck-options.mdx
+++ b/docs/reference/deck-options.mdx
@@ -120,7 +120,7 @@ DeckOptions(
 
 See [Custom Slide Parts Guide](/guides/slide-parts) for examples.
 
-Slides can set `layout: fullscreen` in front matter to suppress the resolved header and footer for that slide while keeping the resolved background, and to zero default block padding and margin. Named styles still merge after those layout defaults.
+Slides can set `layout: fullscreen` in front matter to suppress the resolved header and footer for that slide while keeping the resolved background and style.
 
 ### `debug`
 **Type:** `bool` | **Default:** `false`
@@ -162,7 +162,7 @@ layout: fullscreen
 # This slide uses the 'keynote' template background without header/footer
 ```
 
-When `layout: fullscreen` is combined with a named template, SuperDeck first resolves the template's parts and base style, then removes header/footer chrome, zeroes default block padding and margin, and keeps the template background. Named styles still merge after the layout defaults.
+When `layout: fullscreen` is combined with a named template, SuperDeck first resolves the template's parts and style, then removes header/footer chrome while keeping the template background and resolved style.
 
 ### `defaultTemplate`
 **Type:** `SlideTemplate?` | **Default:** `null`
@@ -179,7 +179,7 @@ DeckOptions(
 )
 ```
 
-`layout: fullscreen` also works with `defaultTemplate`. Setting `template: 'none'` still only opts out of the default template; if the same slide sets `layout: fullscreen`, the deck-level header/footer are removed, default block padding and margin are zeroed, and the deck-level background is preserved.
+`layout: fullscreen` also works with `defaultTemplate`. Setting `template: 'none'` still only opts out of the default template; if the same slide sets `layout: fullscreen`, the deck-level header/footer are removed, and the deck-level background and style are preserved.
 
 ## Complete configuration example
 

--- a/docs/reference/deck-options.mdx
+++ b/docs/reference/deck-options.mdx
@@ -120,7 +120,7 @@ DeckOptions(
 
 See [Custom Slide Parts Guide](/guides/slide-parts) for examples.
 
-Slides can set `layout: fullscreen` in front matter to suppress the resolved header and footer for that slide while keeping the resolved background.
+Slides can set `layout: fullscreen` in front matter to suppress the resolved header and footer for that slide while keeping the resolved background, and to zero default block padding and margin. Named styles still merge after those layout defaults.
 
 ### `debug`
 **Type:** `bool` | **Default:** `false`
@@ -162,7 +162,7 @@ layout: fullscreen
 # This slide uses the 'keynote' template background without header/footer
 ```
 
-When `layout: fullscreen` is combined with a named template, SuperDeck first resolves the template's parts and base style, then removes header/footer chrome and applies full-bleed default block spacing. The template background remains active.
+When `layout: fullscreen` is combined with a named template, SuperDeck first resolves the template's parts and base style, then removes header/footer chrome, zeroes default block padding and margin, and keeps the template background. Named styles still merge after the layout defaults.
 
 ### `defaultTemplate`
 **Type:** `SlideTemplate?` | **Default:** `null`
@@ -179,7 +179,7 @@ DeckOptions(
 )
 ```
 
-`layout: fullscreen` also works with `defaultTemplate`. Setting `template: 'none'` still only opts out of the default template; if the same slide sets `layout: fullscreen`, the deck-level header/footer are removed and the deck-level background is preserved.
+`layout: fullscreen` also works with `defaultTemplate`. Setting `template: 'none'` still only opts out of the default template; if the same slide sets `layout: fullscreen`, the deck-level header/footer are removed, default block padding and margin are zeroed, and the deck-level background is preserved.
 
 ## Complete configuration example
 

--- a/docs/reference/deck-options.mdx
+++ b/docs/reference/deck-options.mdx
@@ -120,6 +120,8 @@ DeckOptions(
 
 See [Custom Slide Parts Guide](/guides/slide-parts) for examples.
 
+Slides can set `layout: fullscreen` in front matter to suppress the resolved header and footer for that slide while keeping the resolved background.
+
 ### `debug`
 **Type:** `bool` | **Default:** `false`
 
@@ -154,10 +156,13 @@ Use in slides:
 ```markdown
 ---
 template: keynote
+layout: fullscreen
 ---
 
-# This slide uses the 'keynote' template
+# This slide uses the 'keynote' template background without header/footer
 ```
+
+When `layout: fullscreen` is combined with a named template, SuperDeck first resolves the template's parts and base style, then removes header/footer chrome and applies full-bleed default block spacing. The template background remains active.
 
 ### `defaultTemplate`
 **Type:** `SlideTemplate?` | **Default:** `null`
@@ -173,6 +178,8 @@ DeckOptions(
   ),
 )
 ```
+
+`layout: fullscreen` also works with `defaultTemplate`. Setting `template: 'none'` still only opts out of the default template; if the same slide sets `layout: fullscreen`, the deck-level header/footer are removed and the deck-level background is preserved.
 
 ## Complete configuration example
 

--- a/docs/reference/markdown-syntax.mdx
+++ b/docs/reference/markdown-syntax.mdx
@@ -30,7 +30,7 @@ owner: Platform Team
 ---
 ````
 
-`layout: fullscreen` creates a full-bleed slide. It removes header and footer chrome from deck parts, named templates, or `defaultTemplate`, preserves the resolved background, and zeroes default block padding and margin. A named `style` still applies after the layout defaults, so it can re-add padding or margins when needed.
+`layout: fullscreen` creates a chrome-free fullscreen slide. It removes header and footer chrome from deck parts, named templates, or `defaultTemplate`, while preserving the resolved background and style.
 
 ## Block types
 

--- a/docs/reference/markdown-syntax.mdx
+++ b/docs/reference/markdown-syntax.mdx
@@ -15,8 +15,9 @@ Supported keys:
 
 - `title`: Slide title used in navigation and exports.
 - `style`: Named style variant from `DeckOptions.styles`.
+- `layout`: Slide layout mode. Use `normal` or `fullscreen`.
 - `template`: Named template from `DeckOptions.templates` (`'none'` to opt out).
-- Custom keys: Available through `slide.options.args['keyName']`.
+- Custom keys: Available through `slide.options.args['keyName']`. Official keys such as `layout` are not included in `args`.
 
 Example:
 
@@ -24,9 +25,12 @@ Example:
 ---
 title: Product Vision
 style: overview
+layout: fullscreen
 owner: Platform Team
 ---
 ````
+
+`layout: fullscreen` creates a full-bleed slide. It removes header and footer chrome from deck parts, named templates, or `defaultTemplate`, preserves the resolved background, and starts with zero default block padding. A named `style` still applies after the fullscreen defaults, so it can re-add padding or margins when needed.
 
 ## Block types
 

--- a/docs/reference/markdown-syntax.mdx
+++ b/docs/reference/markdown-syntax.mdx
@@ -30,7 +30,7 @@ owner: Platform Team
 ---
 ````
 
-`layout: fullscreen` creates a full-bleed slide. It removes header and footer chrome from deck parts, named templates, or `defaultTemplate`, preserves the resolved background, and starts with zero default block padding. A named `style` still applies after the fullscreen defaults, so it can re-add padding or margins when needed.
+`layout: fullscreen` creates a full-bleed slide. It removes header and footer chrome from deck parts, named templates, or `defaultTemplate`, preserves the resolved background, and zeroes default block padding and margin. A named `style` still applies after the layout defaults, so it can re-add padding or margins when needed.
 
 ## Block types
 

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Round-trip the `layout` slide frontmatter option in Markdown serialization.
 - Add build-plugin `beginBuild` and `finishBuild` lifecycle hooks.
 - Make `DeckBuilder.dispose()` wait for queued builds before disposing plugins
   and reject new builds after disposal.

--- a/packages/builder/lib/src/parsers/slide_serializer.dart
+++ b/packages/builder/lib/src/parsers/slide_serializer.dart
@@ -86,6 +86,9 @@ class SlideSerializer {
     final entries = <MapEntry<String, Object?>>[];
     if (options.title != null) entries.add(MapEntry('title', options.title));
     if (options.style != null) entries.add(MapEntry('style', options.style));
+    if (options.layout != null) {
+      entries.add(MapEntry('layout', options.layout!.name));
+    }
     if (options.template != null) {
       entries.add(MapEntry('template', options.template));
     }
@@ -243,21 +246,11 @@ class SlideSerializer {
   }
 
   bool _isYamlKeyword(String value) {
-    const keywords = {
-      'true',
-      'false',
-      'null',
-      'yes',
-      'no',
-      'on',
-      'off',
-      '~',
-    };
+    const keywords = {'true', 'false', 'null', 'yes', 'no', 'on', 'off', '~'};
     return keywords.contains(value.toLowerCase());
   }
 
-  bool _looksNumeric(String value) =>
-      num.tryParse(value) != null;
+  bool _looksNumeric(String value) => num.tryParse(value) != null;
 
   // ---------------------------------------------------------------------------
   // Comments

--- a/packages/builder/test/src/parsers/slide_serializer_test.dart
+++ b/packages/builder/test/src/parsers/slide_serializer_test.dart
@@ -29,6 +29,7 @@ Map<String, Object?> canonicalSlide(Slide slide) {
         : {
             'title': slide.options!.title,
             'style': slide.options!.style,
+            'layout': slide.options!.layout?.name,
             'template': slide.options!.template,
             'args': slide.options!.args,
           },
@@ -99,12 +100,26 @@ void main() {
           '---\n'
           'title: Welcome\n'
           'style: hero\n'
+          'layout: fullscreen\n'
           'template: cover\n'
           'background: dark\n'
           '---\n\n'
           '# Welcome',
         ),
       );
+    });
+
+    test('frontmatter layout normal round-trips as an official option', () {
+      final slides = parseDeck(
+        '---\n'
+        'layout: normal\n'
+        '---\n\n'
+        '# Normal slide',
+      );
+
+      expect(slides.single.options?.layout, SlideLayout.normal);
+      expect(slides.single.options?.args.containsKey('layout'), isFalse);
+      expectRoundTrip(slides);
     });
 
     test('multi-section with flex and align', () {
@@ -191,7 +206,9 @@ void main() {
     );
 
     for (final name in ['coffee', 'polar_bear', 'zebra']) {
-      final deckFile = File('../playground/assets/ai_examples/${name}_deck.json');
+      final deckFile = File(
+        '../playground/assets/ai_examples/${name}_deck.json',
+      );
       test(
         'AI example deck: $name',
         () {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `SlideLayout` and the `SlideOptions.layout` field to the slide contract.
+
 ## 1.0.0
 
 - First stable release of superdeck_core

--- a/packages/core/lib/src/deck/slide_model.dart
+++ b/packages/core/lib/src/deck/slide_model.dart
@@ -8,6 +8,7 @@ part 'slide_model.mapper.dart';
 final slideOptionsSchema = Ack.object({
   'title': Ack.string().optional(),
   'style': Ack.string().optional(),
+  'layout': SlideLayout.schema.optional(),
   'template': Ack.string().optional(),
 }, additionalProperties: true);
 
@@ -50,17 +51,34 @@ class Slide with SlideMappable {
   static Slide parse(Map<String, Object?> map) => fromMap(schema.parse(map)!);
 }
 
+@MappableEnum()
+enum SlideLayout {
+  normal,
+  fullscreen;
+
+  static final schema = Ack.enumValues(values);
+
+  String toJson() => name;
+}
+
 /// Configuration options for a slide.
 ///
 /// Provides metadata and styling information for individual slides.
 @MappableClass(hook: UnmappedPropertiesHook('args'), ignoreNull: true)
 class SlideOptions with SlideOptionsMappable {
-  static const _knownFields = {'title', 'style', 'template'};
+  static const _knownFields = {'title', 'style', 'layout', 'template'};
 
   final String? title;
 
   /// The style variant to apply to this slide.
   final String? style;
+
+  /// The layout mode to apply to this slide.
+  ///
+  /// Missing layout and [SlideLayout.normal] both use the default slide chrome
+  /// and spacing. [SlideLayout.fullscreen] removes slide chrome and uses
+  /// full-bleed default block spacing.
+  final SlideLayout? layout;
 
   /// The slide template to use for chrome and style isolation.
   ///
@@ -73,6 +91,7 @@ class SlideOptions with SlideOptionsMappable {
   SlideOptions({
     this.title,
     this.style,
+    this.layout,
     this.template,
     Map<String, Object?> args = const {},
   }) : args = Map.unmodifiable(

--- a/packages/core/lib/src/deck/slide_model.dart
+++ b/packages/core/lib/src/deck/slide_model.dart
@@ -76,8 +76,9 @@ class SlideOptions with SlideOptionsMappable {
   /// The layout mode to apply to this slide.
   ///
   /// Missing layout and [SlideLayout.normal] both use the default slide chrome
-  /// and spacing. [SlideLayout.fullscreen] removes slide chrome and uses
-  /// full-bleed default block spacing.
+  /// and spacing. [SlideLayout.fullscreen] removes header/footer chrome (keeps
+  /// background) and zeroes default block padding and margin before named style
+  /// merge.
   final SlideLayout? layout;
 
   /// The slide template to use for chrome and style isolation.

--- a/packages/core/lib/src/deck/slide_model.dart
+++ b/packages/core/lib/src/deck/slide_model.dart
@@ -75,10 +75,9 @@ class SlideOptions with SlideOptionsMappable {
 
   /// The layout mode to apply to this slide.
   ///
-  /// Missing layout and [SlideLayout.normal] both use the default slide chrome
-  /// and spacing. [SlideLayout.fullscreen] removes header/footer chrome (keeps
-  /// background) and zeroes default block padding and margin before named style
-  /// merge.
+  /// Missing layout and [SlideLayout.normal] both use the resolved slide parts
+  /// unchanged. [SlideLayout.fullscreen] removes header/footer chrome (keeps
+  /// background) without changing the resolved slide style.
   final SlideLayout? layout;
 
   /// The slide template to use for chrome and style isolation.

--- a/packages/core/lib/src/deck/slide_model.mapper.dart
+++ b/packages/core/lib/src/deck/slide_model.mapper.dart
@@ -8,6 +8,52 @@
 
 part of 'slide_model.dart';
 
+class SlideLayoutMapper extends EnumMapper<SlideLayout> {
+  SlideLayoutMapper._();
+
+  static SlideLayoutMapper? _instance;
+  static SlideLayoutMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = SlideLayoutMapper._());
+    }
+    return _instance!;
+  }
+
+  static SlideLayout fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  SlideLayout decode(dynamic value) {
+    switch (value) {
+      case r'normal':
+        return SlideLayout.normal;
+      case r'fullscreen':
+        return SlideLayout.fullscreen;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(SlideLayout self) {
+    switch (self) {
+      case SlideLayout.normal:
+        return r'normal';
+      case SlideLayout.fullscreen:
+        return r'fullscreen';
+    }
+  }
+}
+
+extension SlideLayoutMapperExtension on SlideLayout {
+  String toValue() {
+    SlideLayoutMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<SlideLayout>(this) as String;
+  }
+}
+
 class SlideMapper extends ClassMapperBase<Slide> {
   SlideMapper._();
 
@@ -190,6 +236,7 @@ class SlideOptionsMapper extends ClassMapperBase<SlideOptions> {
   static SlideOptionsMapper ensureInitialized() {
     if (_instance == null) {
       MapperContainer.globals.use(_instance = SlideOptionsMapper._());
+      SlideLayoutMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -207,6 +254,12 @@ class SlideOptionsMapper extends ClassMapperBase<SlideOptions> {
   static const Field<SlideOptions, String> _f$style = Field(
     'style',
     _$style,
+    opt: true,
+  );
+  static SlideLayout? _$layout(SlideOptions v) => v.layout;
+  static const Field<SlideOptions, SlideLayout> _f$layout = Field(
+    'layout',
+    _$layout,
     opt: true,
   );
   static String? _$template(SlideOptions v) => v.template;
@@ -227,6 +280,7 @@ class SlideOptionsMapper extends ClassMapperBase<SlideOptions> {
   final MappableFields<SlideOptions> fields = const {
     #title: _f$title,
     #style: _f$style,
+    #layout: _f$layout,
     #template: _f$template,
     #args: _f$args,
   };
@@ -239,6 +293,7 @@ class SlideOptionsMapper extends ClassMapperBase<SlideOptions> {
     return SlideOptions(
       title: data.dec(_f$title),
       style: data.dec(_f$style),
+      layout: data.dec(_f$layout),
       template: data.dec(_f$template),
       args: data.dec(_f$args),
     );
@@ -311,6 +366,7 @@ abstract class SlideOptionsCopyWith<$R, $In extends SlideOptions, $Out>
   $R call({
     String? title,
     String? style,
+    SlideLayout? layout,
     String? template,
     Map<String, Object?>? args,
   });
@@ -336,12 +392,14 @@ class _SlideOptionsCopyWithImpl<$R, $Out>
   $R call({
     Object? title = $none,
     Object? style = $none,
+    Object? layout = $none,
     Object? template = $none,
     Map<String, Object?>? args,
   }) => $apply(
     FieldCopyWithData({
       if (title != $none) #title: title,
       if (style != $none) #style: style,
+      if (layout != $none) #layout: layout,
       if (template != $none) #template: template,
       if (args != null) #args: args,
     }),
@@ -350,6 +408,7 @@ class _SlideOptionsCopyWithImpl<$R, $Out>
   SlideOptions $make(CopyWithData data) => SlideOptions(
     title: data.get(#title, or: $value.title),
     style: data.get(#style, or: $value.style),
+    layout: data.get(#layout, or: $value.layout),
     template: data.get(#template, or: $value.template),
     args: data.get(#args, or: $value.args),
   );

--- a/packages/core/schema/superdeck.slides.schema.json
+++ b/packages/core/schema/superdeck.slides.schema.json
@@ -16,6 +16,13 @@
       "options": {
         "additionalProperties": true,
         "properties": {
+          "layout": {
+            "enum": [
+              "normal",
+              "fullscreen"
+            ],
+            "type": "string"
+          },
           "style": {
             "type": "string"
           },

--- a/packages/core/test/src/deck/slide_model_test.dart
+++ b/packages/core/test/src/deck/slide_model_test.dart
@@ -464,18 +464,16 @@ void main() {
           expect(map.containsKey('style'), isFalse);
         });
 
-        test('serializes title and style', () {
-          final options = SlideOptions(title: 'T', style: 'S');
+        test('serializes known fields', () {
+          final options = SlideOptions(
+            title: 'T',
+            style: 'S',
+            layout: SlideLayout.fullscreen,
+          );
           final map = options.toMap();
 
           expect(map['title'], 'T');
           expect(map['style'], 'S');
-        });
-
-        test('serializes layout when present', () {
-          final options = SlideOptions(layout: SlideLayout.fullscreen);
-          final map = options.toMap();
-
           expect(map['layout'], 'fullscreen');
         });
 
@@ -538,18 +536,16 @@ void main() {
           expect(options.args, isEmpty);
         });
 
-        test('deserializes title and style', () {
-          final map = {'title': 'Parsed', 'style': 'parsed-style'};
+        test('deserializes known fields', () {
+          final map = {
+            'title': 'Parsed',
+            'style': 'parsed-style',
+            'layout': 'fullscreen',
+          };
           final options = SlideOptions.fromMap(map);
 
           expect(options.title, 'Parsed');
           expect(options.style, 'parsed-style');
-        });
-
-        test('deserializes layout field', () {
-          final map = {'layout': 'fullscreen'};
-          final options = SlideOptions.fromMap(map);
-
           expect(options.layout, SlideLayout.fullscreen);
         });
 
@@ -558,15 +554,6 @@ void main() {
           final options = SlideOptions.fromMap(map);
 
           expect(options.template, 'parsed-template');
-        });
-
-        test('removes layout from args', () {
-          final map = {'layout': 'fullscreen', 'extra': 'val'};
-          final options = SlideOptions.fromMap(map);
-
-          expect(options.layout, SlideLayout.fullscreen);
-          expect(options.args.containsKey('layout'), isFalse);
-          expect(options.args['extra'], 'val');
         });
 
         test('removes template from args', () {
@@ -605,6 +592,7 @@ void main() {
           expect(options.args.containsKey('style'), isFalse);
           expect(options.args.containsKey('layout'), isFalse);
           expect(options.args.containsKey('template'), isFalse);
+          expect(options.layout, SlideLayout.normal);
           expect(options.args['extra'], 'value');
         });
       });
@@ -614,6 +602,7 @@ void main() {
           final original = SlideOptions(
             title: 'RT',
             style: 'rt-style',
+            layout: SlideLayout.fullscreen,
             args: {'k': 'v'},
           );
 
@@ -621,6 +610,8 @@ void main() {
 
           expect(restored.title, original.title);
           expect(restored.style, original.style);
+          expect(restored.layout, original.layout);
+          expect(restored.args.containsKey('layout'), isFalse);
           expect(restored.args['k'], original.args['k']);
         });
 
@@ -631,15 +622,6 @@ void main() {
 
           expect(restored.template, original.template);
           expect(restored.args.containsKey('template'), isFalse);
-        });
-
-        test('preserves layout through toMap/fromMap', () {
-          final original = SlideOptions(layout: SlideLayout.fullscreen);
-
-          final restored = SlideOptions.fromMap(original.toMap());
-
-          expect(restored.layout, original.layout);
-          expect(restored.args.containsKey('layout'), isFalse);
         });
       });
 
@@ -657,26 +639,20 @@ void main() {
           expect(options.args['extra'], 'value');
         });
 
-        test('parses map with template field', () {
+        test('parses known fields', () {
           final options = SlideOptions.parse({
             'title': 'T',
+            'style': 'S',
+            'layout': 'fullscreen',
             'template': 'parsed-template',
           });
 
           expect(options.title, 'T');
-          expect(options.template, 'parsed-template');
-          expect(options.args.containsKey('template'), isFalse);
-        });
-
-        test('parses map with layout field', () {
-          final options = SlideOptions.parse({
-            'title': 'T',
-            'layout': 'fullscreen',
-          });
-
-          expect(options.title, 'T');
+          expect(options.style, 'S');
           expect(options.layout, SlideLayout.fullscreen);
+          expect(options.template, 'parsed-template');
           expect(options.args.containsKey('layout'), isFalse);
+          expect(options.args.containsKey('template'), isFalse);
         });
       });
 

--- a/packages/core/test/src/deck/slide_model_test.dart
+++ b/packages/core/test/src/deck/slide_model_test.dart
@@ -212,7 +212,7 @@ void main() {
         test(
           'throws AckException when options optional fields are explicitly null',
           () {
-            for (final field in ['title', 'style', 'template']) {
+            for (final field in ['title', 'style', 'layout', 'template']) {
               expect(
                 () => Slide.parse({
                   'key': 'invalid-options',
@@ -349,7 +349,7 @@ void main() {
         });
 
         test('fails validation when options fields are explicitly null', () {
-          for (final field in ['title', 'style', 'template']) {
+          for (final field in ['title', 'style', 'layout', 'template']) {
             final result = Slide.schema.safeParse({
               'key': 'full',
               'options': {field: null},
@@ -367,6 +367,7 @@ void main() {
 
         expect(options.title, isNull);
         expect(options.style, isNull);
+        expect(options.layout, isNull);
         expect(options.args, isEmpty);
       });
 
@@ -374,11 +375,13 @@ void main() {
         final options = SlideOptions(
           title: 'Title',
           style: 'dark',
+          layout: SlideLayout.fullscreen,
           args: {'custom': 'value'},
         );
 
         expect(options.title, 'Title');
         expect(options.style, 'dark');
+        expect(options.layout, SlideLayout.fullscreen);
         expect(options.args['custom'], 'value');
       });
 
@@ -438,6 +441,7 @@ void main() {
           final original = SlideOptions(
             title: 'T',
             style: 'S',
+            layout: SlideLayout.fullscreen,
             template: 'tmpl',
             args: {'k': 'v'},
           );
@@ -445,6 +449,7 @@ void main() {
 
           expect(copy.title, original.title);
           expect(copy.style, original.style);
+          expect(copy.layout, original.layout);
           expect(copy.template, original.template);
           expect(copy.args, original.args);
         });
@@ -465,6 +470,13 @@ void main() {
 
           expect(map['title'], 'T');
           expect(map['style'], 'S');
+        });
+
+        test('serializes layout when present', () {
+          final options = SlideOptions(layout: SlideLayout.fullscreen);
+          final map = options.toMap();
+
+          expect(map['layout'], 'fullscreen');
         });
 
         test('serializes template when present', () {
@@ -497,10 +509,12 @@ void main() {
           final options = SlideOptions(
             title: 'Reserved title',
             style: 'reserved-style',
+            layout: SlideLayout.normal,
             template: 'reserved-template',
             args: {
               'title': 'arg-title',
               'style': 'arg-style',
+              'layout': 'fullscreen',
               'template': 'arg-template',
               'custom': 'value',
             },
@@ -509,6 +523,7 @@ void main() {
 
           expect(map['title'], 'Reserved title');
           expect(map['style'], 'reserved-style');
+          expect(map['layout'], 'normal');
           expect(map['template'], 'reserved-template');
           expect(map['custom'], 'value');
         });
@@ -531,11 +546,27 @@ void main() {
           expect(options.style, 'parsed-style');
         });
 
+        test('deserializes layout field', () {
+          final map = {'layout': 'fullscreen'};
+          final options = SlideOptions.fromMap(map);
+
+          expect(options.layout, SlideLayout.fullscreen);
+        });
+
         test('deserializes template field', () {
           final map = {'template': 'parsed-template'};
           final options = SlideOptions.fromMap(map);
 
           expect(options.template, 'parsed-template');
+        });
+
+        test('removes layout from args', () {
+          final map = {'layout': 'fullscreen', 'extra': 'val'};
+          final options = SlideOptions.fromMap(map);
+
+          expect(options.layout, SlideLayout.fullscreen);
+          expect(options.args.containsKey('layout'), isFalse);
+          expect(options.args['extra'], 'val');
         });
 
         test('removes template from args', () {
@@ -565,12 +596,14 @@ void main() {
           final options = SlideOptions.fromMap({
             'title': 'T',
             'style': 'S',
+            'layout': 'normal',
             'template': 'tmpl',
             'extra': 'value',
           });
 
           expect(options.args.containsKey('title'), isFalse);
           expect(options.args.containsKey('style'), isFalse);
+          expect(options.args.containsKey('layout'), isFalse);
           expect(options.args.containsKey('template'), isFalse);
           expect(options.args['extra'], 'value');
         });
@@ -599,6 +632,15 @@ void main() {
           expect(restored.template, original.template);
           expect(restored.args.containsKey('template'), isFalse);
         });
+
+        test('preserves layout through toMap/fromMap', () {
+          final original = SlideOptions(layout: SlideLayout.fullscreen);
+
+          final restored = SlideOptions.fromMap(original.toMap());
+
+          expect(restored.layout, original.layout);
+          expect(restored.args.containsKey('layout'), isFalse);
+        });
       });
 
       group('parse', () {
@@ -625,6 +667,17 @@ void main() {
           expect(options.template, 'parsed-template');
           expect(options.args.containsKey('template'), isFalse);
         });
+
+        test('parses map with layout field', () {
+          final options = SlideOptions.parse({
+            'title': 'T',
+            'layout': 'fullscreen',
+          });
+
+          expect(options.title, 'T');
+          expect(options.layout, SlideLayout.fullscreen);
+          expect(options.args.containsKey('layout'), isFalse);
+        });
       });
 
       group('equality', () {
@@ -646,6 +699,13 @@ void main() {
         test('different style makes options unequal', () {
           final opt1 = SlideOptions(style: 'light');
           final opt2 = SlideOptions(style: 'dark');
+
+          expect(opt1, isNot(opt2));
+        });
+
+        test('different layout makes options unequal', () {
+          final opt1 = SlideOptions(layout: SlideLayout.normal);
+          final opt2 = SlideOptions(layout: SlideLayout.fullscreen);
 
           expect(opt1, isNot(opt2));
         });
@@ -709,8 +769,25 @@ void main() {
           expect(result.isOk, isTrue);
         });
 
+        test('validates normal and fullscreen layout values', () {
+          expect(
+            SlideOptions.schema.safeParse({'layout': 'normal'}).isOk,
+            isTrue,
+          );
+          expect(
+            SlideOptions.schema.safeParse({'layout': 'fullscreen'}).isOk,
+            isTrue,
+          );
+        });
+
+        test('rejects invalid layout values', () {
+          final result = SlideOptions.schema.safeParse({'layout': 'wide'});
+
+          expect(result.isOk, isFalse);
+        });
+
         test('fails validation when optional fields are explicitly null', () {
-          for (final field in ['title', 'style', 'template']) {
+          for (final field in ['title', 'style', 'layout', 'template']) {
             final result = SlideOptions.schema.safeParse({field: null});
             expect(result.isOk, isFalse);
           }

--- a/packages/superdeck/CHANGELOG.md
+++ b/packages/superdeck/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Support `layout: fullscreen` slides, which suppress resolved headers and
+  footers while preserving the resolved background and style.
 - Export `FileDeckLoader` and `BundledDeckLoader` from the public barrel so
   apps can use `SuperDeckApp.deckLoader` without importing from `src/`.
 - Fall back to bundled deck assets when auto-selection cannot discover a

--- a/packages/superdeck/lib/src/deck/template_resolver.dart
+++ b/packages/superdeck/lib/src/deck/template_resolver.dart
@@ -31,6 +31,10 @@ class TemplateResolutionResult {
 /// - **With template**: `defaultSlideStyle -> template.baseStyle -> layout style -> template.styles[style]`
 /// - **Without template**: `defaultSlideStyle -> options.baseStyle -> layout style -> options.styles[style]`
 /// - **With defaultTemplate**: applies when slide has no explicit template
+///
+/// [SlideLayout.fullscreen] is applied after base style and before the named
+/// style so authors can re-introduce spacing via `style`. Fullscreen also
+/// clears resolved header/footer while preserving the resolved background.
 class TemplateResolver {
   final DeckOptions _options;
 
@@ -51,6 +55,7 @@ class TemplateResolver {
   /// styles even when a defaultTemplate is configured.
   static const noneTemplate = 'none';
 
+  /// Full-bleed block spacing: zero pad and margin after defaults, before named style.
   static final _fullscreenStyle = SlideStyle(
     blockContainer: BoxStyler(
       padding: EdgeInsetsGeometryMix.all(0),

--- a/packages/superdeck/lib/src/deck/template_resolver.dart
+++ b/packages/superdeck/lib/src/deck/template_resolver.dart
@@ -1,3 +1,4 @@
+import 'package:mix/mix.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 
 import '../rendering/slides/slide_parts.dart';
@@ -27,8 +28,8 @@ class TemplateResolutionResult {
 /// Resolves slide templates and styles from [DeckOptions].
 ///
 /// Resolution order:
-/// - **With template**: `defaultSlideStyle -> template.baseStyle -> template.styles[style]`
-/// - **Without template**: `defaultSlideStyle -> options.baseStyle -> options.styles[style]`
+/// - **With template**: `defaultSlideStyle -> template.baseStyle -> layout style -> template.styles[style]`
+/// - **Without template**: `defaultSlideStyle -> options.baseStyle -> layout style -> options.styles[style]`
 /// - **With defaultTemplate**: applies when slide has no explicit template
 class TemplateResolver {
   final DeckOptions _options;
@@ -50,6 +51,13 @@ class TemplateResolver {
   /// styles even when a defaultTemplate is configured.
   static const noneTemplate = 'none';
 
+  static final _fullscreenStyle = SlideStyle(
+    blockContainer: BoxStyler(
+      padding: EdgeInsetsGeometryMix.all(0),
+      margin: EdgeInsetsGeometryMix.all(0),
+    ),
+  );
+
   /// Resolves the style and parts for a slide based on its options.
   ///
   /// Throws [ArgumentError] if:
@@ -59,6 +67,7 @@ class TemplateResolver {
   TemplateResolutionResult resolve(SlideOptions? slideOptions) {
     final templateName = slideOptions?.template;
     final styleName = slideOptions?.style;
+    final layout = slideOptions?.layout;
 
     // Determine which template to use (explicit > default > none)
     final template = _resolveTemplate(templateName);
@@ -68,10 +77,11 @@ class TemplateResolver {
         template,
         templateName ?? 'defaultTemplate',
         styleName,
+        layout,
       );
     }
 
-    return _resolveWithoutTemplate(styleName);
+    return _resolveWithoutTemplate(styleName, layout);
   }
 
   SlideTemplate? _resolveTemplate(String? templateName) {
@@ -100,6 +110,7 @@ class TemplateResolver {
     SlideTemplate template,
     String templateName,
     String? styleName,
+    SlideLayout? layout,
   ) {
     SlideStyle? styleOverride;
     if (styleName != null) {
@@ -114,16 +125,20 @@ class TemplateResolver {
 
     final mergedStyle = defaultSlideStyle
         .merge(template.baseStyle)
+        .merge(_layoutStyle(layout))
         .merge(styleOverride);
 
     return TemplateResolutionResult(
       style: mergedStyle,
-      parts: template.parts,
+      parts: _resolveParts(template.parts, layout),
       usingTemplate: true,
     );
   }
 
-  TemplateResolutionResult _resolveWithoutTemplate(String? styleName) {
+  TemplateResolutionResult _resolveWithoutTemplate(
+    String? styleName,
+    SlideLayout? layout,
+  ) {
     SlideStyle? styleOverride;
     if (styleName != null) {
       styleOverride = _options.styles[styleName];
@@ -137,12 +152,23 @@ class TemplateResolver {
 
     final mergedStyle = defaultSlideStyle
         .merge(_options.baseStyle)
+        .merge(_layoutStyle(layout))
         .merge(styleOverride);
 
     return TemplateResolutionResult(
       style: mergedStyle,
-      parts: _options.parts,
+      parts: _resolveParts(_options.parts, layout),
       usingTemplate: false,
     );
+  }
+
+  SlideStyle? _layoutStyle(SlideLayout? layout) {
+    return layout == SlideLayout.fullscreen ? _fullscreenStyle : null;
+  }
+
+  SlideParts _resolveParts(SlideParts parts, SlideLayout? layout) {
+    if (layout != SlideLayout.fullscreen) return parts;
+
+    return SlideParts(header: null, footer: null, background: parts.background);
   }
 }

--- a/packages/superdeck/lib/src/deck/template_resolver.dart
+++ b/packages/superdeck/lib/src/deck/template_resolver.dart
@@ -1,4 +1,3 @@
-import 'package:mix/mix.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 
 import '../rendering/slides/slide_parts.dart';
@@ -28,13 +27,12 @@ class TemplateResolutionResult {
 /// Resolves slide templates and styles from [DeckOptions].
 ///
 /// Resolution order:
-/// - **With template**: `defaultSlideStyle -> template.baseStyle -> layout style -> template.styles[style]`
-/// - **Without template**: `defaultSlideStyle -> options.baseStyle -> layout style -> options.styles[style]`
+/// - **With template**: `defaultSlideStyle -> template.baseStyle -> template.styles[style]`
+/// - **Without template**: `defaultSlideStyle -> options.baseStyle -> options.styles[style]`
 /// - **With defaultTemplate**: applies when slide has no explicit template
 ///
-/// [SlideLayout.fullscreen] is applied after base style and before the named
-/// style so authors can re-introduce spacing via `style`. Fullscreen also
-/// clears resolved header/footer while preserving the resolved background.
+/// [SlideLayout.fullscreen] clears resolved header/footer while preserving the
+/// resolved background and style.
 class TemplateResolver {
   final DeckOptions _options;
 
@@ -54,14 +52,6 @@ class TemplateResolver {
   /// Use `template: 'none'` in slide options to fall back to deck-level
   /// styles even when a defaultTemplate is configured.
   static const noneTemplate = 'none';
-
-  /// Full-bleed block spacing: zero pad and margin after defaults, before named style.
-  static final _fullscreenStyle = SlideStyle(
-    blockContainer: BoxStyler(
-      padding: EdgeInsetsGeometryMix.all(0),
-      margin: EdgeInsetsGeometryMix.all(0),
-    ),
-  );
 
   /// Resolves the style and parts for a slide based on its options.
   ///
@@ -130,7 +120,6 @@ class TemplateResolver {
 
     final mergedStyle = defaultSlideStyle
         .merge(template.baseStyle)
-        .merge(_layoutStyle(layout))
         .merge(styleOverride);
 
     return TemplateResolutionResult(
@@ -157,7 +146,6 @@ class TemplateResolver {
 
     final mergedStyle = defaultSlideStyle
         .merge(_options.baseStyle)
-        .merge(_layoutStyle(layout))
         .merge(styleOverride);
 
     return TemplateResolutionResult(
@@ -165,10 +153,6 @@ class TemplateResolver {
       parts: _resolveParts(_options.parts, layout),
       usingTemplate: false,
     );
-  }
-
-  SlideStyle? _layoutStyle(SlideLayout? layout) {
-    return layout == SlideLayout.fullscreen ? _fullscreenStyle : null;
   }
 
   SlideParts _resolveParts(SlideParts parts, SlideLayout? layout) {

--- a/packages/superdeck/test/src/deck/template_resolver_test.dart
+++ b/packages/superdeck/test/src/deck/template_resolver_test.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
 import 'package:superdeck/src/deck/template_resolver.dart';
 import 'package:superdeck/superdeck.dart';
 import 'package:superdeck_core/superdeck_core.dart';
@@ -503,6 +505,152 @@ void main() {
         expect(withTemplate.parts, template.parts);
         expect(withoutTemplate.parts, options.parts);
       });
+    });
+
+    group('Fullscreen layout', () {
+      test('layout normal behaves like omitted layout', () {
+        final baseStyle = SlideStyle();
+        final options = DeckOptions(baseStyle: baseStyle);
+        final resolver = TemplateResolver(options);
+
+        final omitted = resolver.resolve(null);
+        final normal = resolver.resolve(
+          SlideOptions(layout: SlideLayout.normal),
+        );
+
+        expect(normal.usingTemplate, omitted.usingTemplate);
+        expect(normal.parts, same(omitted.parts));
+        expect(normal.style, defaultSlideStyle.merge(baseStyle).merge(null));
+      });
+
+      test(
+        'suppresses deck-level header and footer while preserving background',
+        () {
+          const background = ColoredBox(color: Color(0xFF123456));
+          final options = DeckOptions(
+            parts: const SlideParts(background: background),
+          );
+          final resolver = TemplateResolver(options);
+          final slideOptions = SlideOptions(layout: SlideLayout.fullscreen);
+
+          final result = resolver.resolve(slideOptions);
+
+          expect(result.usingTemplate, isFalse);
+          expect(result.parts.header, isNull);
+          expect(result.parts.footer, isNull);
+          expect(result.parts.background, same(background));
+        },
+      );
+
+      test(
+        'suppresses template header and footer while preserving background',
+        () {
+          const background = ColoredBox(color: Color(0xFF654321));
+          final template = SlideTemplate(
+            parts: const SlideParts(background: background),
+          );
+          final options = DeckOptions(templates: {'cover': template});
+          final resolver = TemplateResolver(options);
+          final slideOptions = SlideOptions(
+            template: 'cover',
+            layout: SlideLayout.fullscreen,
+          );
+
+          final result = resolver.resolve(slideOptions);
+
+          expect(result.usingTemplate, isTrue);
+          expect(result.parts.header, isNull);
+          expect(result.parts.footer, isNull);
+          expect(result.parts.background, same(background));
+        },
+      );
+
+      test('suppresses defaultTemplate header and footer', () {
+        final defaultTemplate = SlideTemplate();
+        final options = DeckOptions(defaultTemplate: defaultTemplate);
+        final resolver = TemplateResolver(options);
+        final slideOptions = SlideOptions(layout: SlideLayout.fullscreen);
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isTrue);
+        expect(result.parts.header, isNull);
+        expect(result.parts.footer, isNull);
+      });
+
+      test(
+        'template: none remains deck-level with fullscreen chrome removal',
+        () {
+          const background = ColoredBox(color: Color(0xFFABCDEF));
+          final options = DeckOptions(
+            defaultTemplate: SlideTemplate(),
+            parts: const SlideParts(background: background),
+          );
+          final resolver = TemplateResolver(options);
+          final slideOptions = SlideOptions(
+            template: 'none',
+            layout: SlideLayout.fullscreen,
+          );
+
+          final result = resolver.resolve(slideOptions);
+
+          expect(result.usingTemplate, isFalse);
+          expect(result.parts.header, isNull);
+          expect(result.parts.footer, isNull);
+          expect(result.parts.background, same(background));
+        },
+      );
+
+      test('zeroes default block padding and margin', () {
+        final options = DeckOptions();
+        final resolver = TemplateResolver(options);
+        final slideOptions = SlideOptions(layout: SlideLayout.fullscreen);
+        final fullscreenStyle = SlideStyle(
+          blockContainer: BoxStyler(
+            padding: EdgeInsetsGeometryMix.all(0),
+            margin: EdgeInsetsGeometryMix.all(0),
+          ),
+        );
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(
+          result.style,
+          defaultSlideStyle.merge(null).merge(fullscreenStyle).merge(null),
+        );
+      });
+
+      test(
+        'named style can re-add block padding after fullscreen defaults',
+        () {
+          final namedStyle = SlideStyle(
+            blockContainer: BoxStyler(padding: EdgeInsetsGeometryMix.all(24)),
+          );
+          final options = DeckOptions(styles: {'inset': namedStyle});
+          final resolver = TemplateResolver(options);
+          final slideOptions = SlideOptions(
+            layout: SlideLayout.fullscreen,
+            style: 'inset',
+          );
+
+          final result = resolver.resolve(slideOptions);
+
+          expect(
+            result.style,
+            defaultSlideStyle
+                .merge(null)
+                .merge(
+                  SlideStyle(
+                    blockContainer: BoxStyler(
+                      padding: EdgeInsetsGeometryMix.all(0),
+                      margin: EdgeInsetsGeometryMix.all(0),
+                    ),
+                  ),
+                )
+                .merge(namedStyle),
+          );
+        },
+      );
     });
   });
 }

--- a/packages/superdeck/test/src/deck/template_resolver_test.dart
+++ b/packages/superdeck/test/src/deck/template_resolver_test.dart
@@ -508,14 +508,6 @@ void main() {
     });
 
     group('Fullscreen layout', () {
-      /// Zero pad/margin injected by fullscreen before named style merge.
-      final fullscreenBlockSpacing = SlideStyle(
-        blockContainer: BoxStyler(
-          padding: EdgeInsetsGeometryMix.all(0),
-          margin: EdgeInsetsGeometryMix.all(0),
-        ),
-      );
-
       void expectFullscreenChrome(
         TemplateResolutionResult result, {
         required Widget background,
@@ -618,8 +610,14 @@ void main() {
         },
       );
 
-      test('zeroes default block padding and margin after base style', () {
-        final options = DeckOptions();
+      test('preserves resolved style without layout-specific overrides', () {
+        final baseStyle = SlideStyle(
+          blockContainer: BoxStyler(
+            padding: EdgeInsetsGeometryMix.all(32),
+            margin: EdgeInsetsGeometryMix.all(16),
+          ),
+        );
+        final options = DeckOptions(baseStyle: baseStyle);
         final resolver = TemplateResolver(options);
 
         final normal = resolver.resolve(null);
@@ -627,31 +625,8 @@ void main() {
           SlideOptions(layout: SlideLayout.fullscreen),
         );
 
-        // Outcome: fullscreen is normal resolution plus full-bleed spacing only.
-        expect(fullscreen.style, normal.style.merge(fullscreenBlockSpacing));
-        expect(fullscreen.style, isNot(normal.style));
+        expect(fullscreen.style, normal.style);
       });
-
-      test(
-        'named style can re-add block padding after fullscreen defaults',
-        () {
-          final namedStyle = SlideStyle(
-            blockContainer: BoxStyler(padding: EdgeInsetsGeometryMix.all(24)),
-          );
-          final options = DeckOptions(styles: {'inset': namedStyle});
-          final resolver = TemplateResolver(options);
-
-          final fullscreenOnly = resolver.resolve(
-            SlideOptions(layout: SlideLayout.fullscreen),
-          );
-          final withNamed = resolver.resolve(
-            SlideOptions(layout: SlideLayout.fullscreen, style: 'inset'),
-          );
-
-          // Outcome: named style merges after fullscreen spacing.
-          expect(withNamed.style, fullscreenOnly.style.merge(namedStyle));
-        },
-      );
     });
   });
 }

--- a/packages/superdeck/test/src/deck/template_resolver_test.dart
+++ b/packages/superdeck/test/src/deck/template_resolver_test.dart
@@ -508,6 +508,10 @@ void main() {
     });
 
     group('Fullscreen layout', () {
+      SlideOptions fullscreenOptions({String? template}) {
+        return SlideOptions(template: template, layout: SlideLayout.fullscreen);
+      }
+
       void expectFullscreenChrome(
         TemplateResolutionResult result, {
         required Widget background,
@@ -544,7 +548,7 @@ void main() {
           final resolver = TemplateResolver(options);
 
           expectFullscreenChrome(
-            resolver.resolve(SlideOptions(layout: SlideLayout.fullscreen)),
+            resolver.resolve(fullscreenOptions()),
             background: background,
             usingTemplate: false,
           );
@@ -562,9 +566,7 @@ void main() {
           final resolver = TemplateResolver(options);
 
           expectFullscreenChrome(
-            resolver.resolve(
-              SlideOptions(template: 'cover', layout: SlideLayout.fullscreen),
-            ),
+            resolver.resolve(fullscreenOptions(template: 'cover')),
             background: background,
             usingTemplate: true,
           );
@@ -583,7 +585,7 @@ void main() {
           final resolver = TemplateResolver(options);
 
           expectFullscreenChrome(
-            resolver.resolve(SlideOptions(layout: SlideLayout.fullscreen)),
+            resolver.resolve(fullscreenOptions()),
             background: background,
             usingTemplate: true,
           );
@@ -601,9 +603,7 @@ void main() {
           final resolver = TemplateResolver(options);
 
           expectFullscreenChrome(
-            resolver.resolve(
-              SlideOptions(template: 'none', layout: SlideLayout.fullscreen),
-            ),
+            resolver.resolve(fullscreenOptions(template: 'none')),
             background: background,
             usingTemplate: false,
           );
@@ -621,9 +621,7 @@ void main() {
         final resolver = TemplateResolver(options);
 
         final normal = resolver.resolve(null);
-        final fullscreen = resolver.resolve(
-          SlideOptions(layout: SlideLayout.fullscreen),
-        );
+        final fullscreen = resolver.resolve(fullscreenOptions());
 
         expect(fullscreen.style, normal.style);
       });

--- a/packages/superdeck/test/src/deck/template_resolver_test.dart
+++ b/packages/superdeck/test/src/deck/template_resolver_test.dart
@@ -508,10 +508,6 @@ void main() {
     });
 
     group('Fullscreen layout', () {
-      SlideOptions fullscreenOptions({String? template}) {
-        return SlideOptions(template: template, layout: SlideLayout.fullscreen);
-      }
-
       void expectFullscreenChrome(
         TemplateResolutionResult result, {
         required Widget background,
@@ -548,7 +544,7 @@ void main() {
           final resolver = TemplateResolver(options);
 
           expectFullscreenChrome(
-            resolver.resolve(fullscreenOptions()),
+            resolver.resolve(SlideOptions(layout: SlideLayout.fullscreen)),
             background: background,
             usingTemplate: false,
           );
@@ -566,7 +562,9 @@ void main() {
           final resolver = TemplateResolver(options);
 
           expectFullscreenChrome(
-            resolver.resolve(fullscreenOptions(template: 'cover')),
+            resolver.resolve(
+              SlideOptions(template: 'cover', layout: SlideLayout.fullscreen),
+            ),
             background: background,
             usingTemplate: true,
           );
@@ -585,7 +583,7 @@ void main() {
           final resolver = TemplateResolver(options);
 
           expectFullscreenChrome(
-            resolver.resolve(fullscreenOptions()),
+            resolver.resolve(SlideOptions(layout: SlideLayout.fullscreen)),
             background: background,
             usingTemplate: true,
           );
@@ -603,7 +601,9 @@ void main() {
           final resolver = TemplateResolver(options);
 
           expectFullscreenChrome(
-            resolver.resolve(fullscreenOptions(template: 'none')),
+            resolver.resolve(
+              SlideOptions(template: 'none', layout: SlideLayout.fullscreen),
+            ),
             background: background,
             usingTemplate: false,
           );
@@ -621,7 +621,9 @@ void main() {
         final resolver = TemplateResolver(options);
 
         final normal = resolver.resolve(null);
-        final fullscreen = resolver.resolve(fullscreenOptions());
+        final fullscreen = resolver.resolve(
+          SlideOptions(layout: SlideLayout.fullscreen),
+        );
 
         expect(fullscreen.style, normal.style);
       });

--- a/packages/superdeck/test/src/deck/template_resolver_test.dart
+++ b/packages/superdeck/test/src/deck/template_resolver_test.dart
@@ -508,6 +508,25 @@ void main() {
     });
 
     group('Fullscreen layout', () {
+      /// Zero pad/margin injected by fullscreen before named style merge.
+      final fullscreenBlockSpacing = SlideStyle(
+        blockContainer: BoxStyler(
+          padding: EdgeInsetsGeometryMix.all(0),
+          margin: EdgeInsetsGeometryMix.all(0),
+        ),
+      );
+
+      void expectFullscreenChrome(
+        TemplateResolutionResult result, {
+        required Widget background,
+        required bool usingTemplate,
+      }) {
+        expect(result.usingTemplate, usingTemplate);
+        expect(result.parts.header, isNull);
+        expect(result.parts.footer, isNull);
+        expect(result.parts.background, same(background));
+      }
+
       test('layout normal behaves like omitted layout', () {
         final baseStyle = SlideStyle();
         final options = DeckOptions(baseStyle: baseStyle);
@@ -520,7 +539,7 @@ void main() {
 
         expect(normal.usingTemplate, omitted.usingTemplate);
         expect(normal.parts, same(omitted.parts));
-        expect(normal.style, defaultSlideStyle.merge(baseStyle).merge(null));
+        expect(normal.style, omitted.style);
       });
 
       test(
@@ -531,14 +550,12 @@ void main() {
             parts: const SlideParts(background: background),
           );
           final resolver = TemplateResolver(options);
-          final slideOptions = SlideOptions(layout: SlideLayout.fullscreen);
 
-          final result = resolver.resolve(slideOptions);
-
-          expect(result.usingTemplate, isFalse);
-          expect(result.parts.header, isNull);
-          expect(result.parts.footer, isNull);
-          expect(result.parts.background, same(background));
+          expectFullscreenChrome(
+            resolver.resolve(SlideOptions(layout: SlideLayout.fullscreen)),
+            background: background,
+            usingTemplate: false,
+          );
         },
       );
 
@@ -551,32 +568,35 @@ void main() {
           );
           final options = DeckOptions(templates: {'cover': template});
           final resolver = TemplateResolver(options);
-          final slideOptions = SlideOptions(
-            template: 'cover',
-            layout: SlideLayout.fullscreen,
+
+          expectFullscreenChrome(
+            resolver.resolve(
+              SlideOptions(template: 'cover', layout: SlideLayout.fullscreen),
+            ),
+            background: background,
+            usingTemplate: true,
           );
-
-          final result = resolver.resolve(slideOptions);
-
-          expect(result.usingTemplate, isTrue);
-          expect(result.parts.header, isNull);
-          expect(result.parts.footer, isNull);
-          expect(result.parts.background, same(background));
         },
       );
 
-      test('suppresses defaultTemplate header and footer', () {
-        final defaultTemplate = SlideTemplate();
-        final options = DeckOptions(defaultTemplate: defaultTemplate);
-        final resolver = TemplateResolver(options);
-        final slideOptions = SlideOptions(layout: SlideLayout.fullscreen);
+      test(
+        'suppresses defaultTemplate header and footer while preserving background',
+        () {
+          const background = ColoredBox(color: Color(0xFF112233));
+          final options = DeckOptions(
+            defaultTemplate: SlideTemplate(
+              parts: const SlideParts(background: background),
+            ),
+          );
+          final resolver = TemplateResolver(options);
 
-        final result = resolver.resolve(slideOptions);
-
-        expect(result.usingTemplate, isTrue);
-        expect(result.parts.header, isNull);
-        expect(result.parts.footer, isNull);
-      });
+          expectFullscreenChrome(
+            resolver.resolve(SlideOptions(layout: SlideLayout.fullscreen)),
+            background: background,
+            usingTemplate: true,
+          );
+        },
+      );
 
       test(
         'template: none remains deck-level with fullscreen chrome removal',
@@ -587,37 +607,29 @@ void main() {
             parts: const SlideParts(background: background),
           );
           final resolver = TemplateResolver(options);
-          final slideOptions = SlideOptions(
-            template: 'none',
-            layout: SlideLayout.fullscreen,
+
+          expectFullscreenChrome(
+            resolver.resolve(
+              SlideOptions(template: 'none', layout: SlideLayout.fullscreen),
+            ),
+            background: background,
+            usingTemplate: false,
           );
-
-          final result = resolver.resolve(slideOptions);
-
-          expect(result.usingTemplate, isFalse);
-          expect(result.parts.header, isNull);
-          expect(result.parts.footer, isNull);
-          expect(result.parts.background, same(background));
         },
       );
 
-      test('zeroes default block padding and margin', () {
+      test('zeroes default block padding and margin after base style', () {
         final options = DeckOptions();
         final resolver = TemplateResolver(options);
-        final slideOptions = SlideOptions(layout: SlideLayout.fullscreen);
-        final fullscreenStyle = SlideStyle(
-          blockContainer: BoxStyler(
-            padding: EdgeInsetsGeometryMix.all(0),
-            margin: EdgeInsetsGeometryMix.all(0),
-          ),
+
+        final normal = resolver.resolve(null);
+        final fullscreen = resolver.resolve(
+          SlideOptions(layout: SlideLayout.fullscreen),
         );
 
-        final result = resolver.resolve(slideOptions);
-
-        expect(
-          result.style,
-          defaultSlideStyle.merge(null).merge(fullscreenStyle).merge(null),
-        );
+        // Outcome: fullscreen is normal resolution plus full-bleed spacing only.
+        expect(fullscreen.style, normal.style.merge(fullscreenBlockSpacing));
+        expect(fullscreen.style, isNot(normal.style));
       });
 
       test(
@@ -628,27 +640,16 @@ void main() {
           );
           final options = DeckOptions(styles: {'inset': namedStyle});
           final resolver = TemplateResolver(options);
-          final slideOptions = SlideOptions(
-            layout: SlideLayout.fullscreen,
-            style: 'inset',
+
+          final fullscreenOnly = resolver.resolve(
+            SlideOptions(layout: SlideLayout.fullscreen),
+          );
+          final withNamed = resolver.resolve(
+            SlideOptions(layout: SlideLayout.fullscreen, style: 'inset'),
           );
 
-          final result = resolver.resolve(slideOptions);
-
-          expect(
-            result.style,
-            defaultSlideStyle
-                .merge(null)
-                .merge(
-                  SlideStyle(
-                    blockContainer: BoxStyler(
-                      padding: EdgeInsetsGeometryMix.all(0),
-                      margin: EdgeInsetsGeometryMix.all(0),
-                    ),
-                  ),
-                )
-                .merge(namedStyle),
-          );
+          // Outcome: named style merges after fullscreen spacing.
+          expect(withNamed.style, fullscreenOnly.style.merge(namedStyle));
         },
       );
     });

--- a/packages/superdeck/test/src/rendering/slide_view_test.dart
+++ b/packages/superdeck/test/src/rendering/slide_view_test.dart
@@ -162,7 +162,7 @@ void main() {
           key: 'fullscreen',
           options: SlideOptions(layout: SlideLayout.fullscreen),
           sections: [
-            SectionBlock([ContentBlock('Full bleed')]),
+            SectionBlock([ContentBlock('Fullscreen content')]),
           ],
         );
         final configuration =

--- a/packages/superdeck/test/src/rendering/slide_view_test.dart
+++ b/packages/superdeck/test/src/rendering/slide_view_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:superdeck/superdeck.dart';
+import 'package:superdeck/src/deck/slide_configuration_builder.dart';
 import 'package:superdeck/src/rendering/blocks/block_widget.dart';
 import 'package:superdeck/src/rendering/slides/slide_view.dart';
 import 'package:superdeck/src/ui/widgets/provider.dart';
@@ -152,6 +153,42 @@ void main() {
         expect(topSection.top, closeTo(80, 1.0));
         expect(bottomSection.bottom, closeTo(680, 1.0));
         expect(topSection.height + bottomSection.height, closeTo(600, 1.0));
+      });
+
+      testWidgets('fullscreen sections receive full slide size', (
+        tester,
+      ) async {
+        final slide = Slide(
+          key: 'fullscreen',
+          options: SlideOptions(layout: SlideLayout.fullscreen),
+          sections: [
+            SectionBlock([ContentBlock('Full bleed')]),
+          ],
+        );
+        final configuration =
+            const SlideConfigurationBuilder().buildConfigurations(
+              [slide],
+              DeckOptions(
+                parts: const SlideParts(
+                  header: PreferredSize(
+                    preferredSize: Size.fromHeight(80),
+                    child: SizedBox.shrink(),
+                  ),
+                  footer: PreferredSize(
+                    preferredSize: Size.fromHeight(40),
+                    child: SizedBox.shrink(),
+                  ),
+                ),
+              ),
+            ).single;
+
+        await SlideTestHarness.pumpConfiguration(tester, configuration);
+
+        final section = find.byType(SectionWidget);
+        final sectionRect = tester.getRect(section);
+
+        expect(sectionRect.top, 0);
+        expect(sectionRect.size, const Size(1280, 720));
       });
     });
 


### PR DESCRIPTION
Adds a new slide front matter option, `layout: fullscreen`, backed by `SlideLayout` and `SlideOptions.layout` in `superdeck_core`.

Fullscreen slides remove resolved header/footer chrome while preserving the resolved background and style.

The builder serializer, generated mapper, JSON schema, and docs now include the layout field. Tests cover model parsing/serialization, args reservation, serializer round-trips, template/defaultTemplate behavior, full-size slide rendering, and named style overrides.