### PR TITLE
feat: add BlockVariant for named widget block styles

### DIFF
--- a/demo/macos/Podfile.lock
+++ b/demo/macos/Podfile.lock
@@ -1,15 +1,27 @@
 PODS:
   - FlutterMacOS (1.0.0)
+  - irondash_engine_context (0.0.1):
+    - FlutterMacOS
+  - super_native_extensions (0.0.1):
+    - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - irondash_engine_context (from `Flutter/ephemeral/.symlinks/plugins/irondash_engine_context/macos`)
+  - super_native_extensions (from `Flutter/ephemeral/.symlinks/plugins/super_native_extensions/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
+  irondash_engine_context:
+    :path: Flutter/ephemeral/.symlinks/plugins/irondash_engine_context/macos
+  super_native_extensions:
+    :path: Flutter/ephemeral/.symlinks/plugins/super_native_extensions/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  irondash_engine_context: 893c7d96d20ce361d7e996f39d360c4c2f9869ba
+  super_native_extensions: c2795d6d9aedf4a79fae25cb6160b71b50549189
 
 PODFILE CHECKSUM: 9ebaf0ce3d369aaa26a9ea0e159195ed94724cf3
 

--- a/demo/macos/Runner.xcodeproj/project.pbxproj
+++ b/demo/macos/Runner.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				8A14AB4F804B7CAA2E64DF2E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -391,6 +392,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		8A14AB4F804B7CAA2E64DF2E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		E1EAB9F2FA8DCA9689F733BC /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/docs/reference/deck-options.mdx
+++ b/docs/reference/deck-options.mdx
@@ -67,6 +67,11 @@ final options = DeckOptions(
 precedence after the base style, and its margin and padding are included when
 SuperDeck calculates the child widget's usable size.
 
+SuperDeck already ships this exact zero padding and margin rule for `@webview`
+blocks by default, so a webview renders edge-to-edge without any stylesheet. The
+example above therefore doubles as the pattern for giving any other named block
+its own spacing.
+
 Only `WidgetBlock` names are selectable. Content blocks and section containers
 are not selectable; there are no per-instance IDs, classes, attributes, or
 selector composition. A plain `NamedVariant('image')` remains a manual Mix

--- a/docs/reference/deck-options.mdx
+++ b/docs/reference/deck-options.mdx
@@ -34,6 +34,52 @@ DeckOptions(
 )
 ```
 
+#### Named widget block styles
+
+Use `BlockVariant` in a `SlideStyle` stylesheet to target every named widget
+block with an exact, case-sensitive name. The selector applies to the block
+container and its complete widget subtree, so container spacing and descendant
+Mix styles resolve together.
+
+```dart
+import 'package:mix/mix.dart';
+import 'package:superdeck/superdeck.dart';
+
+const webviewBlock = BlockVariant('webview');
+
+final options = DeckOptions(
+  baseStyle: SlideStyle(
+    blockContainer: BoxStyler(
+      padding: EdgeInsetsGeometryMix.all(40),
+    ).variants([
+      VariantStyle(
+        webviewBlock,
+        BoxStyler(padding: EdgeInsetsGeometryMix.all(0)),
+      ),
+    ]),
+  ),
+);
+```
+
+`BlockVariant('webview')` matches both `@webview` and `@widget` blocks whose
+`name` is `webview`. Custom shorthand annotations work the same way, so
+`@chart` matches `BlockVariant('chart')`. The matching rule uses normal Mix
+precedence after the base style, and its margin and padding are included when
+SuperDeck calculates the child widget's usable size.
+
+Only `WidgetBlock` names are selectable. Content blocks and section containers
+are not selectable; there are no per-instance IDs, classes, attributes, or
+selector composition. A plain `NamedVariant('image')` remains a manual Mix
+variant and is not activated merely because an `@image` block is rendered.
+Every widget block with the same name receives the same rule. Hardcoded styling
+inside a custom widget is unchanged unless that widget declares Mix styles that
+can respond to the inherited `BlockVariant`.
+
+Fullscreen layout does not create a separate block selector. It only removes
+header and footer chrome, so the same `BlockVariant('webview')` rule applies to
+normal and fullscreen WebView blocks; those two layouts cannot receive
+different rules based on `BlockVariant` alone.
+
 ### `styles`
 **Type:** `Map<String, SlideStyle>` | **Default:** `{}`
 

--- a/docs/reference/markdown-syntax.mdx
+++ b/docs/reference/markdown-syntax.mdx
@@ -44,6 +44,18 @@ SuperDeck supports three core block types.
 
 Built-in widgets (`image`, `dartpad`, `webview`, `qrcode`) use the same widget syntax as `@widget`.
 
+### Styling named widget blocks
+
+Widget names can be selected from Dart stylesheets with `BlockVariant`. For
+example, `@webview` and the equivalent `@widget { name: "webview" }` both
+match `BlockVariant('webview')`; `@chart` matches `BlockVariant('chart')`.
+Matching is exact and case-sensitive.
+
+The selector affects the widget block container and descendants in that widget
+subtree. It does not select `@block`, `@section`, individual block instances,
+or arbitrary `NamedVariant` values. See the [DeckOptions reference](/reference/deck-options#named-widget-block-styles)
+for the stylesheet declaration and limitations.
+
 ## Common block properties
 
 ### `flex`

--- a/packages/superdeck/CHANGELOG.md
+++ b/packages/superdeck/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `BlockVariant` for opt-in, name-based `WidgetBlock` styling in Dart
   stylesheets.
+- Render `@webview` blocks edge-to-edge (zero padding and margin) by default.
 - Export `FileDeckLoader` and `BundledDeckLoader` from the public barrel so
   apps can use `SuperDeckApp.deckLoader` without importing from `src/`.
 - Fall back to bundled deck assets when auto-selection cannot discover a

--- a/packages/superdeck/CHANGELOG.md
+++ b/packages/superdeck/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Add `BlockVariant` for opt-in, name-based `WidgetBlock` styling in Dart
   stylesheets.
 - Render `@webview` blocks edge-to-edge (zero padding and margin) by default.
+- Always paint an opaque slide background so background-less slides no longer
+  bleed adjacent slides through during transitions.
 - Export `FileDeckLoader` and `BundledDeckLoader` from the public barrel so
   apps can use `SuperDeckApp.deckLoader` without importing from `src/`.
 - Fall back to bundled deck assets when auto-selection cannot discover a

--- a/packages/superdeck/CHANGELOG.md
+++ b/packages/superdeck/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
-- Support `layout: fullscreen` slides, which suppress resolved headers and
-  footers while preserving the resolved background and style.
+- Add `BlockVariant` for opt-in, name-based `WidgetBlock` styling in Dart
+  stylesheets.
 - Export `FileDeckLoader` and `BundledDeckLoader` from the public barrel so
   apps can use `SuperDeckApp.deckLoader` without importing from `src/`.
 - Fall back to bundled deck assets when auto-selection cannot discover a

--- a/packages/superdeck/lib/src/rendering/blocks/block_widget.dart
+++ b/packages/superdeck/lib/src/rendering/blocks/block_widget.dart
@@ -6,6 +6,7 @@ import 'package:mix/mix.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 
 import '../../deck/slide_configuration.dart';
+import '../../styling/block_variant.dart';
 import '../../styling/components/slide.dart';
 import '../../ui/widgets/error_widgets.dart';
 import '../../ui/widgets/overflow_clip.dart';
@@ -39,8 +40,12 @@ class _BlockContainer extends StatefulWidget {
 class _BlockContainerState extends State<_BlockContainer> {
   @override
   Widget build(context) {
-    // Get the resolved SlideSpec (provided by SlideView)
-    final spec = SlideSpec.of(context);
+    // Widget blocks resolve their style inside [BlockVariantScope] so a named
+    // block variant affects both the rendered container and its child size.
+    final spec = switch (widget.block) {
+      WidgetBlock() => widget.configuration.style.resolve(context).spec,
+      ContentBlock() => SlideSpec.of(context),
+    };
 
     final blockOffset = spec.blockContainer.spec.calculateBlockOffset;
 
@@ -204,12 +209,15 @@ class CustomBlockWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _BlockContainer(
-      block: block,
-      size: size,
-      configuration: configuration,
-      runtimeKey: runtimeKey,
-      child: _CustomBlockChild(block: block),
+    return BlockVariantScope(
+      name: block.name,
+      child: _BlockContainer(
+        block: block,
+        size: size,
+        configuration: configuration,
+        runtimeKey: runtimeKey,
+        child: _CustomBlockChild(block: block),
+      ),
     );
   }
 }

--- a/packages/superdeck/lib/src/rendering/slides/slide_view.dart
+++ b/packages/superdeck/lib/src/rendering/slides/slide_view.dart
@@ -101,6 +101,12 @@ class SlideView extends StatelessWidget {
       size: kResolution,
       child: Stack(
         children: [
+          // Opaque floor so a slide is never transparent: a transparent or
+          // absent background part would otherwise let other slides bleed
+          // through during cross-fade transitions.
+          const Positioned.fill(
+            child: ColoredBox(color: kSlideBackgroundColor),
+          ),
           // Background fills entire viewport (not affected by modifier)
           Positioned.fill(child: backgroundWidget),
           // Content wrapped with StyleBuilder to apply modifiers

--- a/packages/superdeck/lib/src/styling/block_variant.dart
+++ b/packages/superdeck/lib/src/styling/block_variant.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/widgets.dart';
+import 'package:mix/mix.dart';
+
+/// A Mix context selector for a named widget-block container and subtree.
+///
+/// A block variant is active only while building a widget block whose resolved
+/// name exactly matches [name].
+final class BlockVariant extends ContextVariant {
+  /// The widget block name this variant matches.
+  final String name;
+
+  const BlockVariant(this.name) : super('block_$name', _neverMatches);
+
+  @override
+  bool Function(BuildContext) get shouldApply => when;
+
+  @override
+  bool when(BuildContext context) {
+    return BlockVariantScope.maybeOf(context)?.name == name;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is BlockVariant && other.name == name;
+  }
+
+  @override
+  int get hashCode => name.hashCode;
+}
+
+bool _neverMatches(BuildContext _) => false;
+
+/// Provides the current named widget block to descendants.
+///
+/// This scope is used by SuperDeck's renderer. It is intentionally not
+/// exported from the public package barrel.
+class BlockVariantScope extends InheritedWidget {
+  /// The resolved widget-block name for this subtree.
+  final String name;
+
+  const BlockVariantScope({
+    super.key,
+    required this.name,
+    required super.child,
+  });
+
+  /// Returns the nearest block variant scope, if one is active.
+  static BlockVariantScope? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<BlockVariantScope>();
+  }
+
+  @override
+  bool updateShouldNotify(BlockVariantScope oldWidget) {
+    return name != oldWidget.name;
+  }
+}

--- a/packages/superdeck/lib/src/styling/default_style.dart
+++ b/packages/superdeck/lib/src/styling/default_style.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mix/mix.dart';
 
+import 'block_variant.dart';
 import 'components/markdown_alert.dart';
 import 'components/markdown_alert_type.dart';
 import 'components/markdown_blockquote.dart';
@@ -29,6 +30,11 @@ TextStyle get _baseTextStyle => _safeGoogleFont(
 
 const onGist = NamedVariant('gist');
 const onImage = NamedVariant('image');
+
+// A webview fills its own block, so it ships edge-to-edge by default. This uses
+// [BlockVariant] because a plain [NamedVariant] does not activate for a rendered
+// widget block; only [BlockVariant] reliably targets the `@webview` container.
+const onWebview = BlockVariant('webview');
 
 WidgetModifierConfig _pad(EdgeInsetsGeometryMix value) =>
     WidgetModifierConfig.padding(value);
@@ -225,6 +231,13 @@ SlideStyle _createDefaultSlideStyle() {
       VariantStyle(onImage, BoxStyler(padding: EdgeInsetsGeometryMix.all(0))),
       VariantStyle(
         onGist,
+        BoxStyler(
+          padding: EdgeInsetsGeometryMix.all(0),
+          margin: EdgeInsetsGeometryMix.all(0),
+        ),
+      ),
+      VariantStyle(
+        onWebview,
         BoxStyler(
           padding: EdgeInsetsGeometryMix.all(0),
           margin: EdgeInsetsGeometryMix.all(0),

--- a/packages/superdeck/lib/src/ui/app_shell.dart
+++ b/packages/superdeck/lib/src/ui/app_shell.dart
@@ -274,7 +274,7 @@ class _SplitViewState extends State<SplitView>
         final buildFailure = deckController.session.buildFailure.value;
 
         return Scaffold(
-          backgroundColor: const Color.fromARGB(255, 9, 9, 9),
+          backgroundColor: kSlideBackgroundColor,
           floatingActionButtonLocation:
               FloatingActionButtonLocation.miniEndFloat,
           floatingActionButton: _buildFloatingAction(

--- a/packages/superdeck/lib/src/utils/constants.dart
+++ b/packages/superdeck/lib/src/utils/constants.dart
@@ -8,5 +8,14 @@ const _kHeight = 720.0;
 
 const kResolution = Size(_kWidth, _kHeight);
 
+/// Opaque backdrop painted behind a slide when no background part is set.
+///
+/// Guarantees a slide is never transparent: without it, a background-less slide
+/// (e.g. a template with no chrome) would show through to whatever is behind it,
+/// which bleeds the outgoing/incoming slide through during cross-fade
+/// transitions. Matches the app shell letterbox so the default is invisible
+/// except during transitions.
+const kSlideBackgroundColor = Color(0xFF090909);
+
 const kIsTest = bool.fromEnvironment('FLUTTER_TEST');
 const kCanRunProcess = kDebugMode && !kIsWeb && !kIsTest;

--- a/packages/superdeck/lib/superdeck.dart
+++ b/packages/superdeck/lib/superdeck.dart
@@ -12,6 +12,7 @@ export 'src/thumbnails/async_thumbnail.dart';
 export 'src/thumbnails/thumbnail_service.dart';
 
 // Styling
+export 'src/styling/block_variant.dart' show BlockVariant;
 export 'src/styling/default_style.dart';
 export 'src/styling/components/markdown_alert.dart';
 export 'src/styling/components/markdown_alert_type.dart';

--- a/packages/superdeck/test/src/rendering/block_widget_test.dart
+++ b/packages/superdeck/test/src/rendering/block_widget_test.dart
@@ -365,6 +365,31 @@ void main() {
         expect(gistSize, const Size(560, 540));
       });
 
+      testWidgets('gives webview blocks zero padding and margin by default', (
+        tester,
+      ) async {
+        _setSlideViewport(tester);
+        late Size webviewSize;
+
+        await SlideTestHarness.pumpSlide(
+          tester,
+          Slide(
+            key: 'default-webview-spacing',
+            sections: [
+              SectionBlock([WidgetBlock(name: 'webview')]),
+            ],
+          ),
+          widgets: {
+            'webview': (_) =>
+                _BlockSizeProbe(onBuild: (size) => webviewSize = size),
+          },
+        );
+
+        // Full block size with no padding/margin subtracted (default 40 padding
+        // would yield 1200x540).
+        expect(webviewSize, const Size(1280, 620));
+      });
+
       testWidgets(
         'exposes the active selector to a nested Mix-styled descendant',
         (tester) async {

--- a/packages/superdeck/test/src/rendering/block_widget_test.dart
+++ b/packages/superdeck/test/src/rendering/block_widget_test.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:superdeck/superdeck.dart' show BlockVariant, SlideStyle;
+import 'package:superdeck/src/rendering/blocks/block_provider.dart';
 import 'package:superdeck/src/rendering/blocks/block_widget.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 
@@ -214,6 +217,219 @@ void main() {
       });
     });
 
+    group('named widget block variants', () {
+      testWidgets(
+        'changes only the matching custom widget container and its usable size',
+        (tester) async {
+          _setSlideViewport(tester);
+          late Size chartSize;
+          late Size siblingSize;
+
+          await SlideTestHarness.pumpSlide(
+            tester,
+            Slide(
+              key: 'custom-block-variant',
+              sections: [
+                SectionBlock([
+                  WidgetBlock(name: 'chart'),
+                  WidgetBlock(name: 'sibling'),
+                ]),
+              ],
+            ),
+            style: SlideStyle(
+              blockContainer: BoxStyler(padding: EdgeInsetsGeometryMix.all(40))
+                  .variants([
+                    VariantStyle(
+                      const BlockVariant('chart'),
+                      BoxStyler(padding: EdgeInsetsGeometryMix.all(0)),
+                    ),
+                  ]),
+            ),
+            widgets: {
+              'chart': (_) =>
+                  _BlockSizeProbe(onBuild: (size) => chartSize = size),
+              'sibling': (_) =>
+                  _BlockSizeProbe(onBuild: (size) => siblingSize = size),
+            },
+          );
+
+          expect(chartSize, const Size(640, 620));
+          expect(siblingSize, const Size(560, 540));
+        },
+      );
+
+      testWidgets(
+        'applies the same selector to equivalent resolved widget blocks',
+        (tester) async {
+          _setSlideViewport(tester);
+          final sizes = <String, Size>{};
+
+          await SlideTestHarness.pumpSlide(
+            tester,
+            Slide(
+              key: 'equivalent-webview-blocks',
+              sections: [
+                SectionBlock([
+                  WidgetBlock(
+                    name: 'webview',
+                    args: const {'source': 'shorthand'},
+                  ),
+                  WidgetBlock(
+                    name: 'webview',
+                    args: const {'source': 'widget'},
+                  ),
+                ]),
+              ],
+            ),
+            style: SlideStyle(
+              blockContainer: BoxStyler(padding: EdgeInsetsGeometryMix.all(40))
+                  .variants([
+                    VariantStyle(
+                      const BlockVariant('webview'),
+                      BoxStyler(padding: EdgeInsetsGeometryMix.all(0)),
+                    ),
+                  ]),
+            ),
+            widgets: {
+              'webview': (args) => _BlockSizeProbe(
+                onBuild: (size) => sizes[args['source']! as String] = size,
+              ),
+            },
+          );
+
+          expect(sizes, {
+            'shorthand': const Size(640, 620),
+            'widget': const Size(640, 620),
+          });
+        },
+      );
+
+      testWidgets('keeps plain NamedVariant rules inactive for named blocks', (
+        tester,
+      ) async {
+        _setSlideViewport(tester);
+        late Size imageSize;
+
+        await SlideTestHarness.pumpSlide(
+          tester,
+          Slide(
+            key: 'legacy-named-variant',
+            sections: [
+              SectionBlock([WidgetBlock(name: 'image')]),
+            ],
+          ),
+          style: SlideStyle(
+            blockContainer: BoxStyler(padding: EdgeInsetsGeometryMix.all(40))
+                .variants([
+                  VariantStyle(
+                    const NamedVariant('image'),
+                    BoxStyler(padding: EdgeInsetsGeometryMix.all(0)),
+                  ),
+                ]),
+          ),
+          widgets: {
+            'image': (_) =>
+                _BlockSizeProbe(onBuild: (size) => imageSize = size),
+          },
+        );
+
+        expect(imageSize, const Size(1200, 540));
+      });
+
+      testWidgets('keeps default image and gist container spacing unchanged', (
+        tester,
+      ) async {
+        _setSlideViewport(tester);
+        late Size imageSize;
+        late Size gistSize;
+
+        await SlideTestHarness.pumpSlide(
+          tester,
+          Slide(
+            key: 'default-image-gist-spacing',
+            sections: [
+              SectionBlock([
+                WidgetBlock(name: 'image'),
+                WidgetBlock(name: 'gist'),
+              ]),
+            ],
+          ),
+          widgets: {
+            'image': (_) =>
+                _BlockSizeProbe(onBuild: (size) => imageSize = size),
+            'gist': (_) => _BlockSizeProbe(onBuild: (size) => gistSize = size),
+          },
+        );
+
+        expect(imageSize, const Size(560, 540));
+        expect(gistSize, const Size(560, 540));
+      });
+
+      testWidgets(
+        'exposes the active selector to a nested Mix-styled descendant',
+        (tester) async {
+          _setSlideViewport(tester);
+          await SlideTestHarness.pumpSlide(
+            tester,
+            Slide(
+              key: 'nested-mix-descendant',
+              sections: [
+                SectionBlock([WidgetBlock(name: 'webview')]),
+              ],
+            ),
+            widgets: {'webview': (_) => const _VariantAwareWidget()},
+          );
+
+          final paddings = tester
+              .widgetList<Container>(find.byType(Container))
+              .map((container) => container.padding)
+              .toList();
+
+          expect(paddings, contains(const EdgeInsets.all(24)));
+        },
+      );
+
+      testWidgets(
+        'uses matching variant margin and padding once in BlockConfiguration',
+        (tester) async {
+          _setSlideViewport(tester);
+          late Size blockSize;
+
+          await SlideTestHarness.pumpSlide(
+            tester,
+            Slide(
+              key: 'variant-layout-offset',
+              sections: [
+                SectionBlock([WidgetBlock(name: 'webview')]),
+              ],
+            ),
+            style: SlideStyle(
+              blockContainer:
+                  BoxStyler(
+                    padding: EdgeInsetsGeometryMix.all(10),
+                    margin: EdgeInsetsGeometryMix.all(5),
+                  ).variants([
+                    VariantStyle(
+                      const BlockVariant('webview'),
+                      BoxStyler(
+                        padding: EdgeInsetsGeometryMix.all(20),
+                        margin: EdgeInsetsGeometryMix.all(10),
+                      ),
+                    ),
+                  ]),
+            ),
+            widgets: {
+              'webview': (_) =>
+                  _BlockSizeProbe(onBuild: (size) => blockSize = size),
+            },
+          );
+
+          expect(blockSize, const Size(1220, 560));
+          expect(tester.takeException(), isNull);
+        },
+      );
+    });
+
     group('markdown content types', () {
       testWidgets('renders headings and lists', (tester) async {
         await SlideTestHarness.pumpSlide(tester, SlideFixtures.mixedMarkdown());
@@ -253,6 +469,42 @@ class _TallWidget extends StatelessWidget {
       ),
     );
   }
+}
+
+class _BlockSizeProbe extends StatelessWidget {
+  const _BlockSizeProbe({required this.onBuild});
+
+  final ValueChanged<Size> onBuild;
+
+  @override
+  Widget build(BuildContext context) {
+    onBuild(BlockConfiguration.of(context).size);
+    return const SizedBox.shrink();
+  }
+}
+
+class _VariantAwareWidget extends StatelessWidget {
+  const _VariantAwareWidget();
+
+  @override
+  Widget build(BuildContext context) {
+    return Box(
+      style: BoxStyler(padding: EdgeInsetsGeometryMix.all(4)).variants([
+        VariantStyle(
+          const BlockVariant('webview'),
+          BoxStyler(padding: EdgeInsetsGeometryMix.all(24)),
+        ),
+      ]),
+      child: const SizedBox(width: 1, height: 1),
+    );
+  }
+}
+
+void _setSlideViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1280, 720);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
 }
 
 Alignment _toAlignment(ContentAlignment alignment) {

--- a/packages/superdeck/test/src/rendering/slide_view_test.dart
+++ b/packages/superdeck/test/src/rendering/slide_view_test.dart
@@ -7,6 +7,7 @@ import 'package:superdeck/src/rendering/blocks/block_provider.dart';
 import 'package:superdeck/src/rendering/blocks/block_widget.dart';
 import 'package:superdeck/src/rendering/slides/slide_view.dart';
 import 'package:superdeck/src/ui/widgets/provider.dart';
+import 'package:superdeck/src/utils/constants.dart' show kSlideBackgroundColor;
 import 'package:superdeck_core/superdeck_core.dart';
 
 import '../../helpers/layout_assertions.dart';
@@ -32,6 +33,41 @@ void main() {
 
         expect(find.byType(SlideView), findsOneWidget);
         expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('paints an opaque default background when none is set', (
+        tester,
+      ) async {
+        await SlideTestHarness.pumpSlide(tester, Slide(key: 'no-bg'));
+
+        expect(
+          find.byWidgetPredicate(
+            (w) => w is ColoredBox && w.color == kSlideBackgroundColor,
+          ),
+          findsOneWidget,
+        );
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('keeps the opaque floor beneath a configured background', (
+        tester,
+      ) async {
+        await SlideTestHarness.pumpSlide(
+          tester,
+          Slide(key: 'has-bg'),
+          parts: const SlideParts(
+            background: SizedBox(key: ValueKey('custom-bg')),
+          ),
+        );
+
+        expect(find.byKey(const ValueKey('custom-bg')), findsOneWidget);
+        // The floor persists under a custom background so opacity is guaranteed.
+        expect(
+          find.byWidgetPredicate(
+            (w) => w is ColoredBox && w.color == kSlideBackgroundColor,
+          ),
+          findsOneWidget,
+        );
       });
 
       testWidgets('renders in debug mode without throwing', (tester) async {

--- a/packages/superdeck/test/src/rendering/slide_view_test.dart
+++ b/packages/superdeck/test/src/rendering/slide_view_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
 import 'package:superdeck/superdeck.dart';
 import 'package:superdeck/src/deck/slide_configuration_builder.dart';
+import 'package:superdeck/src/rendering/blocks/block_provider.dart';
 import 'package:superdeck/src/rendering/blocks/block_widget.dart';
 import 'package:superdeck/src/rendering/slides/slide_view.dart';
 import 'package:superdeck/src/ui/widgets/provider.dart';
@@ -190,6 +192,61 @@ void main() {
         expect(sectionRect.top, 0);
         expect(sectionRect.size, const Size(1280, 720));
       });
+
+      testWidgets(
+        'fullscreen removes only chrome and preserves named block styles',
+        (tester) async {
+          late Size blockSize;
+          final slide = Slide(
+            key: 'fullscreen-block-variant',
+            options: SlideOptions(layout: SlideLayout.fullscreen),
+            sections: [
+              SectionBlock([WidgetBlock(name: 'webview')]),
+            ],
+          );
+          final configuration =
+              const SlideConfigurationBuilder().buildConfigurations(
+                [slide],
+                DeckOptions(
+                  baseStyle: SlideStyle(
+                    blockContainer:
+                        BoxStyler(
+                          padding: EdgeInsetsGeometryMix.all(40),
+                        ).variants([
+                          VariantStyle(
+                            const BlockVariant('webview'),
+                            BoxStyler(padding: EdgeInsetsGeometryMix.all(0)),
+                          ),
+                        ]),
+                  ),
+                  widgets: {
+                    'webview': (_) => Builder(
+                      builder: (context) {
+                        blockSize = BlockConfiguration.of(context).size;
+                        return const SizedBox.shrink();
+                      },
+                    ),
+                  },
+                  parts: const SlideParts(
+                    header: PreferredSize(
+                      preferredSize: Size.fromHeight(80),
+                      child: SizedBox.shrink(),
+                    ),
+                    footer: PreferredSize(
+                      preferredSize: Size.fromHeight(40),
+                      child: SizedBox.shrink(),
+                    ),
+                  ),
+                ),
+              ).single;
+
+          await SlideTestHarness.pumpConfiguration(tester, configuration);
+
+          expect(configuration.parts!.header, isNull);
+          expect(configuration.parts!.footer, isNull);
+          expect(blockSize, const Size(1280, 720));
+        },
+      );
     });
 
     group('slide size', () {

--- a/packages/superdeck/test/src/styling/block_variant_test.dart
+++ b/packages/superdeck/test/src/styling/block_variant_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:superdeck/superdeck.dart' show BlockVariant;
+import 'package:superdeck/src/styling/block_variant.dart'
+    show BlockVariantScope;
+
+void main() {
+  group('BlockVariant', () {
+    testWidgets('matches only the exact, case-sensitive block name', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlockVariantScope(
+            name: 'webview',
+            child: Builder(
+              builder: (context) {
+                expect(const BlockVariant('webview').when(context), isTrue);
+                expect(
+                  const BlockVariant('webview').shouldApply(context),
+                  isTrue,
+                );
+                expect(const BlockVariant('WebView').when(context), isFalse);
+                expect(
+                  const BlockVariant('WebView').shouldApply(context),
+                  isFalse,
+                );
+                expect(const BlockVariant('image').when(context), isFalse);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+    });
+
+    testWidgets('uses the nearest scope for nested widget blocks', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlockVariantScope(
+            name: 'webview',
+            child: Column(
+              children: [
+                Builder(
+                  builder: (context) {
+                    expect(const BlockVariant('webview').when(context), isTrue);
+                    return const SizedBox.shrink();
+                  },
+                ),
+                BlockVariantScope(
+                  name: 'chart',
+                  child: Builder(
+                    builder: (context) {
+                      expect(const BlockVariant('chart').when(context), isTrue);
+                      expect(
+                        const BlockVariant('webview').when(context),
+                        isFalse,
+                      );
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                ),
+                Builder(
+                  builder: (context) {
+                    expect(const BlockVariant('webview').when(context), isTrue);
+                    return const SizedBox.shrink();
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    });
+
+    testWidgets('does not leak outside its widget subtree', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Column(
+            children: [
+              BlockVariantScope(
+                name: 'image',
+                child: Builder(
+                  builder: (context) {
+                    expect(const BlockVariant('image').when(context), isTrue);
+                    return const SizedBox.shrink();
+                  },
+                ),
+              ),
+              Builder(
+                builder: (context) {
+                  expect(const BlockVariant('image').when(context), isFalse);
+                  return const SizedBox.shrink();
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Adds `BlockVariant`, an opt-in Mix context selector that lets Dart stylesheets target a named `WidgetBlock` (e.g. `@webview`, `@chart`) without adding style fields to Markdown, block arguments, or frontmatter. Each widget block now resolves its container style inside an internal `BlockVariantScope`, so a matching variant affects both the rendered container and the child's calculated size together. Existing `NamedVariant` rules and default image/gist spacing are unaffected unless a stylesheet explicitly adds a `BlockVariant` rule. Includes docs updates for `deck-options` and `markdown-syntax`, a CHANGELOG entry, and new widget/rendering tests covering matching, sibling isolation, and layout sizing.