### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,10 @@ on:
       - "docs.json"
       - ".github/workflows/docs.yml"
 
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

New pushes currently leave superseded pull-request runs executing. Cancel older runs of each changed workflow for the same PR so runner time is spent on the latest commit. Other PRs and non-PR runs retain their existing behavior.

- `.github/workflows/docs.yml`

## Validation

- YAML parsing and structural comparison passed: only `concurrency` changed.
- `git diff --no-index --check` found no whitespace errors.
- `actionlint -shellcheck= -pyflakes=` passed for every changed workflow.

Application suites were not run locally for this workflow-only patch. Keep this PR in draft until applicable CI completes. Live cancellation behavior remains to be checked by pushing again while a PR run is active; a `pull_request_target` workflow uses the base-branch definition until this change is merged.


## CI verification snapshot

All reported checks for commit `b51b6f91a424e6d5aa0e8aabdd5a7ee6a651f58c` have completed successfully or were intentionally skipped, as of 2026-09-11T16:05:09+00:00. No failing or pending checks were reported.
